### PR TITLE
Updated pytoken script hash reference to script_hash_token

### DIFF
--- a/boa/code/vmtoken.py
+++ b/boa/code/vmtoken.py
@@ -867,11 +867,11 @@ class VMTokenizer():
 
         # the following converts app calls of the pattern
         # m = AppCall(script_hash, *args)
-        if pytoken.script_hash_addr is not None:
+        if pytoken.script_hash_token is not None:
 
             from boa.code.items import SmartContractAppCall
 
-            shash = SmartContractAppCall.ToScriptHashData(pytoken.script_hash_addr)
+            shash = SmartContractAppCall.ToScriptHashData(pytoken.script_hash_token)
 
             vmtoken = self.convert1(VMOp.APPCALL, py_token=pytoken, data=shash)
             return vmtoken


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
N/A

**What problem does this PR solve?**
Code attempts to reference `pytoken.script_hash_addr` which does not exist, leading to compile errors.

**How did you solve this problem?**
Changed attribute reference to `pytoken.script_hash_token`

**How did you make sure your solution works?**
Successfully compiling a contract which uses `RegisterAppCall()`

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
Occurred while using neo-python/prompt.py `build` call 
