### PR TITLE
Feature new opcodes

### DIFF
--- a/boa/blockchain/vm/VMOp.py
+++ b/boa/blockchain/vm/VMOp.py
@@ -126,7 +126,8 @@ PICKITEM = b'\xC3'
 SETITEM = b'\xC4'
 NEWARRAY = b'\xC5'  # 用作引用類型
 NEWSTRUCT = b'\xC6'  # 用作值類型
-
+APPEND = b'\xC8'
+REVERSE = b'\xC9'
 
 DEBUGOP = b'\xFB'
 

--- a/boa/code/block.py
+++ b/boa/code/block.py
@@ -190,13 +190,6 @@ class Block():
                 return True
         return False
 
-    @property
-    def has_array_append(self):
-        for token in self.oplist:
-            if token.py_op == pyop.LOAD_ATTR and token.instance_type is None and token.args == 'append':
-                return True
-        return False
-
     def preprocess_store_attr(self, method):
 
         for index, token in enumerate(self.oplist):
@@ -269,7 +262,7 @@ class Block():
                             what_to_load = token.args
 
                     else:
-                        what_to_load = token.args
+                        what_to_load = 'Get%s' % token.args
 
                     if not do_nothing:
                         if is_func_call:

--- a/boa/code/block.py
+++ b/boa/code/block.py
@@ -261,7 +261,11 @@ class Block():
                             what_to_load = token.args
 
                     else:
-                        what_to_load = 'Get%s' % token.args
+                        if token.args != 'reverse':
+                            what_to_load = 'Get%s' % token.args
+                        else:
+                            what_to_load = 'reverse'
+
 
                     if not do_nothing:
                         if is_func_call:
@@ -273,7 +277,6 @@ class Block():
                             call_func.func_params = [self.oplist[index - 1]]
                             index_to_rep = index
                             new_call = call_func
-
                         else:
                             new_call = PyToken(Opcode(pyop.LOAD_CLASS_ATTR), lineno=self.line, args=what_to_load)
                             new_call.instance_type = ivar_type
@@ -295,11 +298,12 @@ class Block():
                 else:
                     pdb.set_trace()
 
-#        print("oplist: %s " % [str(op) for op in self.oplist])
-        # pdb.set_trace()
+        #print("oplist: %s " % [str(op) for op in self.oplist])
+        #pdb.set_trace()
 
     def preprocess_load_class(self, method):
-        print("PREPROCESS LOAD BUilD CLASS: %s %s " % (method, method.name))
+#        print("PREPROCESS LOAD BUilD CLASS: %s %s " % (method, method.name))
+        pass
 
     def preprocess_make_function(self, method):
         """
@@ -550,18 +554,17 @@ class Block():
         ivars = {}
 
         alreadythere = False
+        delete_this_token = None
 
         while self.has_unprocessed_method_calls:
             start_index_change = None
             end_index_change = None
             changed_items = None
-
             klass = None
 
             for index, token in enumerate(self.oplist):
 
                 if token.py_op == pyop.CALL_FUNCTION and not token.func_processed:
-
                     token.func_processed = True
 
                     param_count = token.args
@@ -576,6 +579,10 @@ class Block():
                     call_method_op = self.oplist[index - param_count - 1]
                     call_method_type = call_method_op.py_op
                     call_method_name = call_method_op.args
+
+                    if call_method_name == 'reverse':
+                        delete_this_token = token
+                        continue
 
                     if call_method_op.instance_type:
 
@@ -645,8 +652,10 @@ class Block():
             #            pdb.set_trace()
 
             if self.oplist[-1].py_op == pyop.STORE_FAST:
-                print("Trimming load self method")
                 self.oplist = self.oplist[-2:]
+
+        if delete_this_token:
+            self.oplist.remove(delete_this_token)
 
         return ivars
 

--- a/boa/code/method.py
+++ b/boa/code/method.py
@@ -456,6 +456,7 @@ class Method():
 
         alltokens = []
 
+
         for block in self.blocks:
             if block.has_make_function:
                 pass

--- a/boa/code/method.py
+++ b/boa/code/method.py
@@ -456,7 +456,6 @@ class Method():
 
         alltokens = []
 
-
         for block in self.blocks:
             if block.has_make_function:
                 pass

--- a/boa/code/pytoken.py
+++ b/boa/code/pytoken.py
@@ -9,7 +9,8 @@ from boa.blockchain.vm import VMOp
 import pdb
 import inspect
 
-NON_RETURN_SYS_CALLS = ['Notify', 'print', 'Log', 'Put', 'Register', 'reverse',
+NON_RETURN_SYS_CALLS = ['Notify', 'print', 'Log', 'Put', 'Register',
+                        'reverse', 'append',
                         'Delete', 'SetVotes', 'ContractDestroy',
                         'MerkleRoot', 'Hash', 'PrevHash', 'GetHeader', ]
 

--- a/boa/code/pytoken.py
+++ b/boa/code/pytoken.py
@@ -9,7 +9,7 @@ from boa.blockchain.vm import VMOp
 import pdb
 import inspect
 
-NON_RETURN_SYS_CALLS = ['Notify', 'print', 'Log', 'Put', 'Register',
+NON_RETURN_SYS_CALLS = ['Notify', 'print', 'Log', 'Put', 'Register', 'reverse',
                         'Delete', 'SetVotes', 'ContractDestroy',
                         'MerkleRoot', 'Hash', 'PrevHash', 'GetHeader', ]
 

--- a/boa/code/vmtoken.py
+++ b/boa/code/vmtoken.py
@@ -653,7 +653,6 @@ class VMTokenizer():
         :return:
         """
 
-
         if pytoken.func_name == 'list':
             return self.convert_built_in_list(pytoken)
         elif pytoken.func_name == 'bytearray':
@@ -707,7 +706,6 @@ class VMTokenizer():
             if fname == m.name:
                 full_name = m.full_name
 
-
         # operational call like len(items) or abs(value)
         if self.is_op_call(fname):
             vmtoken = self.convert_op_call(fname, pytoken)
@@ -748,7 +746,8 @@ class VMTokenizer():
         :param op:
         :return:
         """
-        if op in ['len', 'abs', 'min', 'max', 'concat', 'take', 'substr','reverse',
+        if op in ['len', 'abs', 'min', 'max', 'concat', 'take', 'substr',
+                  'reverse', 'append',
                   'sha1', 'sha256', 'hash160', 'hash256',
                   'verify_signature', 'verify_signatures']:
             return True
@@ -789,6 +788,9 @@ class VMTokenizer():
             return self.convert1(VMOp.CHECKMULTISIG, pytoken)
         elif op == 'reverse':
             return self.convert1(VMOp.REVERSE, pytoken)
+        elif op == 'append':
+            #            pdb.set_trace()
+            return self.convert1(VMOp.APPEND, pytoken)
 
         return None
 
@@ -825,7 +827,7 @@ class VMTokenizer():
         :return:
         """
         if op in ['zip', 'type', 'tuple', 'super', 'str', 'slice',
-                  'set', 'reversed','property', 'memoryview',
+                  'set', 'reversed', 'property', 'memoryview',
                   'map', 'list', 'frozenset', 'float', 'filter',
                   'enumerate', 'dict', 'divmod', 'complex', 'bytes', 'bytearray', 'bool',
                   'int', 'vars', 'sum', 'sorted', 'round', 'setattr', 'getattr',
@@ -853,6 +855,9 @@ class VMTokenizer():
             self.insert1(VMOp.NOP)
             return vmtoken
 
+        elif op == 'reversed':
+            raise NotImplementedError(
+                "[Compilation error] Built in %s is not implemented. Use array.reverse() instead." % op)
 
         raise NotImplementedError(
             "[Compilation error] Built in %s is not implemented" % op)

--- a/boa/code/vmtoken.py
+++ b/boa/code/vmtoken.py
@@ -653,6 +653,7 @@ class VMTokenizer():
         :return:
         """
 
+
         if pytoken.func_name == 'list':
             return self.convert_built_in_list(pytoken)
         elif pytoken.func_name == 'bytearray':
@@ -706,6 +707,7 @@ class VMTokenizer():
             if fname == m.name:
                 full_name = m.full_name
 
+
         # operational call like len(items) or abs(value)
         if self.is_op_call(fname):
             vmtoken = self.convert_op_call(fname, pytoken)
@@ -746,7 +748,7 @@ class VMTokenizer():
         :param op:
         :return:
         """
-        if op in ['len', 'abs', 'min', 'max', 'concat', 'take', 'substr',
+        if op in ['len', 'abs', 'min', 'max', 'concat', 'take', 'substr','reverse',
                   'sha1', 'sha256', 'hash160', 'hash256',
                   'verify_signature', 'verify_signatures']:
             return True
@@ -785,6 +787,9 @@ class VMTokenizer():
             return self.convert1(VMOp.CHECKSIG, pytoken)
         elif op == 'verify_signatures':
             return self.convert1(VMOp.CHECKMULTISIG, pytoken)
+        elif op == 'reverse':
+            return self.convert1(VMOp.REVERSE, pytoken)
+
         return None
 
     def is_sys_call(self, op):
@@ -820,7 +825,7 @@ class VMTokenizer():
         :return:
         """
         if op in ['zip', 'type', 'tuple', 'super', 'str', 'slice',
-                  'set', 'reversed', 'property', 'memoryview',
+                  'set', 'reversed','property', 'memoryview',
                   'map', 'list', 'frozenset', 'float', 'filter',
                   'enumerate', 'dict', 'divmod', 'complex', 'bytes', 'bytearray', 'bool',
                   'int', 'vars', 'sum', 'sorted', 'round', 'setattr', 'getattr',
@@ -847,6 +852,7 @@ class VMTokenizer():
             vmtoken = self.convert1(VMOp.SYSCALL, pytoken, data=ba)
             self.insert1(VMOp.NOP)
             return vmtoken
+
 
         raise NotImplementedError(
             "[Compilation error] Built in %s is not implemented" % op)

--- a/boa/tests/src/AppendTest.py
+++ b/boa/tests/src/AppendTest.py
@@ -1,0 +1,27 @@
+from boa.blockchain.vm.Neo.Runtime import Notify
+
+
+def Main():
+    """
+
+    :return:
+    """
+    m = [1, 2, 4, 'blah']
+
+    m.append(7)
+
+    q = [6, 7]
+
+    l = 'howdy'
+
+    m.append(l)
+
+    m.append(q)
+
+    m.append(b'\x01')
+
+#    answer = j[0]
+
+    Notify(m)
+
+    return m[5]

--- a/boa/tests/src/ArrayReverseTest.py
+++ b/boa/tests/src/ArrayReverseTest.py
@@ -1,0 +1,23 @@
+from boa.blockchain.vm.Neo.Runtime import Notify
+
+def Main():
+
+    # lets have fun
+
+    # this dosen't work. sad
+    #        m = [[1,2,3],'fun','cool','neo']
+    """
+
+    :return:
+    """
+    m = [1,2,4,'blah']
+
+    m.reverse()
+
+
+
+    Notify(m)
+
+#    answer = j[0]
+
+    return m[0]

--- a/boa/tests/src/ArrayReverseTest.py
+++ b/boa/tests/src/ArrayReverseTest.py
@@ -1,5 +1,6 @@
 from boa.blockchain.vm.Neo.Runtime import Notify
 
+
 def Main():
 
     # lets have fun
@@ -10,14 +11,12 @@ def Main():
 
     :return:
     """
-    m = [1,2,4,'blah']
+    m = [1, 2, 4, 'blah']
 
     m.reverse()
 
-
-
     Notify(m)
 
-#    answer = j[0]
+    m.reverse()
 
     return m[0]


### PR DESCRIPTION
Implementing new VM Opcodes recently introduced to the C# VM in this issue:
https://github.com/neo-project/neo/issues/117

This goes along with neo-python commit https://github.com/CityOfZion/neo-python/commit/476da05e7bed2663bb419548095d3c0c40183677, which provides VM support for these OpCodes

So... now we can do this in a smart contract:
```
m = [1, 2, 4]
m.reverse()

m.append(8)

Notify(m) # this will output [4,2,1,8]
```
