### PR TITLE
Print function arguments more clearly

### DIFF
--- a/boa/blockchain/vm/VMOp.py
+++ b/boa/blockchain/vm/VMOp.py
@@ -151,14 +151,6 @@ def ToName(op):
         n = getattr(module, item)
 
         try:
-            nn = int(binascii.hexlify(n))
-
-            if op == nn:
-                return item
-        except Exception as e:
-            pass
-
-        try:
             nn2 = int.from_bytes(n, 'little')
             if op == nn2:
                 return item

--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -537,21 +537,26 @@ class Module():
                             pass
 
                 if pt.py_op == pyop.CALL_FUNCTION:
-                    old = to_label
-                    to_label = '%s %s %s' % (pt.func_name, pt.func_params, old)
+                    if to_label is None:
+                        old = ""
+                    else:
+                        old = to_label
+                    param_string = "("
+                    for param in pt.func_params:
+                        param_string += str(param.args) + ", "
+                    param_string = param_string.rstrip(", ") + ")"
+                    to_label = '%s %s %s' % (pt.func_name, param_string, old)
 
                 lno = "{:<10}".format(
                     pt.line_no if do_print_line_no or pstart else '')
                 addr = "{:<5}".format(key)
                 op = "{:<20}".format(str(pt.py_op))
-                try:
-                    # Check if it is an integer (this is likely a custom boa op)
-                    int(str(pt.py_op))
-                    opname = pyop.ToName(pt.py_op)
+
+                # If this is a number, it is likely a custom python opcode, get the name
+                if str(pt.py_op).isnumeric():
+                    opname = pyop.ToName(int(str(pt.py_op)))
                     if opname is not None:
                         op = "{:<20}".format(opname)
-                except ValueError:
-                    pass
 
                 arg = "{:<50}".format(
                     to_label if to_label is not None else pt.arg_s)

--- a/boa/code/pyop.py
+++ b/boa/code/pyop.py
@@ -199,4 +199,4 @@ def ToName(op):
         n = getattr(module, item)
         if op == n:
             return item
-        return None
+    return None


### PR DESCRIPTION
Modified boa.code.module Module.to_s() to print function params more clearly.
Reworked integer check to eliminate try/except/pass
Fixed indentation for correct name lookup


**What current issue(s) from Github does this address?**

none

**What problem does this PR solve?**

* Fixed name lookup for custom python tokens (indentation error)
* use string.isnumeric() instead of a try/catch/pass to eliminate an unneeded context
* print function parameters clearly (instead of printing pytoken addresses)

**How did you solve this problem?**
* I implemented local tests for to_s() and discovered the bug
* if CALL_FUNCTION then print the value of the pytoken as a comma-delimited list in parans
Then: 
```
              81   CALL_FUNCTION       Put [<boa.code.pytoken.PyToken object at 0x102405f60>, <boa.code.pytoken.PyToken object at 0x102405da0>, <boa.code.pytoken.PyToken object at 0x102405f98>] None[data] 154799572512145549411058089145246502415
```
Now:
```
              81   CALL_FUNCTION       Put (context, b'data', data)                      [data] 154799572512145549411058089145246502415

```

**How did you make sure your solution works?**

Tested manually with a variety of function calls. No automated testing yet.

**Are there any special changes in the code that we should be aware of?**

None

**Is there anything else we should know?**

Don't paste your private key into a webpage.