### PR TITLE
Fix Attribute class naming so methods work in VM

### DIFF
--- a/boa/blockchain/vm/Neo/Attribute.py
+++ b/boa/blockchain/vm/Neo/Attribute.py
@@ -1,5 +1,5 @@
 
-class TransactionAttribute:
+class Attribute:
 
     @property
     def Usage(self):

--- a/boa/blockchain/vm/Neo/Attribute.py
+++ b/boa/blockchain/vm/Neo/Attribute.py
@@ -1,5 +1,5 @@
 
-class Attribute:
+class TransactionAttribute:
 
     @property
     def Usage(self):


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
None AFAIK

**What problem does this PR solve?**
The TransactionAttribute class wasn't working. I was running code like this:
```
from boa.blockchain.vm.Neo. TransactionAttribute import GetData
...
attributes = tx.Attributes
attribute = attributes[0]
sending_script_hash = GetData(attribute)
# Error here!
print(sending_script_hash)
```

Error was:

```
[I 180126 00:11:53 InteropService:304] method Neo.TransactionAttribute.GetData not found in ->
[I 180126 00:11:53 InteropService:306] Neo.Asset.GetOwner -> <bound method StateReader.Asset_GetOwner of <neo.SmartContract.StateReader.StateReader object at 0x111c05ef0>>
[I 180126 00:11:53 InteropService:306] AntShares.Header.GetNextConsensus -> <bound method StateReader.Header_GetNextConsensus of <neo.SmartContract.StateReader.StateReader object at 0x111c05ef0>>
```

**How did you solve this problem?**
Renamed the class to match what the VM expects.

**How did you make sure your solution works?**
Now my code works and getData returns the data I expect.

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No
