### PR TITLE
Replace byteplay3 with bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ dist
 build
 neo_boa.egg-info
 *.egg-info
+*.pyc
 /build

--- a/boa/code/block.py
+++ b/boa/code/block.py
@@ -1,8 +1,7 @@
-
-from byteplay3 import Opcode
 from boa.code.pytoken import PyToken
 from boa.code import pyop
 from boa.code.vmtoken import NEO_SC_FRAMEWORK
+from bytecode.instr import Compare
 import pdb
 
 
@@ -270,7 +269,7 @@ class Block(object):
                     if not do_nothing:
                         if is_func_call:
                             call_func = PyToken(
-                                Opcode(pyop.CALL_FUNCTION), lineno=self.line, index=-1, args=what_to_load)
+                                pyop.CALL_FUNCTION, lineno=self.line, index=-1, args=what_to_load)
                             call_func.instance_type = ivar_type
                             call_func.func_processed = True
                             call_func.func_name = what_to_load
@@ -280,7 +279,7 @@ class Block(object):
                             new_call = call_func
 
                         else:
-                            new_call = PyToken(Opcode(pyop.LOAD_CLASS_ATTR), lineno=self.line, args=what_to_load)
+                            new_call = PyToken(pyop.LOAD_CLASS_ATTR, lineno=self.line, args=what_to_load)
                             new_call.instance_type = ivar_type
                             new_call.instance_name = varname
                             new_call.func_processed = True
@@ -374,11 +373,11 @@ class Block(object):
         self.iterable_loopcounter = 'forloop_counter_%s' % Block.forloop_counter
 
         # load the value 0
-        loopcounter_start_ld_const = PyToken(
-            op=Opcode(pyop.LOAD_CONST), lineno=loopsetup.line_no, index=-1, args=0)
+        loopcounter_start_ld_const = PyToken(op=pyop.LOAD_CONST,
+            lineno=loopsetup.line_no, index=-1, args=0)
         # now store the loop counter
-        loopcounter_store_fast = PyToken(op=Opcode(
-            pyop.STORE_FAST), lineno=loopsetup.line_no, index=-1, args=self.iterable_loopcounter)
+        loopcounter_store_fast = PyToken(op=pyop.STORE_FAST,
+            lineno=loopsetup.line_no, index=-1, args=self.iterable_loopcounter)
 
         # this loads the list that is going to be iterated over ( LOAD_FAST )
         # this will be removed... its added into the call get length token function params
@@ -395,7 +394,7 @@ class Block(object):
 
             self.iterable_item_name = 'forloop_dynamic_range_%s' % Block.forloop_counter
 
-            dynamic_iterator_store_fast = PyToken(op=Opcode(pyop.STORE_FAST), lineno=loopsetup.line_no, index=-1,
+            dynamic_iterator_store_fast = PyToken(op=pyop.STORE_FAST, lineno=loopsetup.line_no, index=-1,
                                                   args=self.iterable_item_name)
 
             # if we're calling a method in this for i in, like for i in range(x,y) then we need
@@ -405,8 +404,7 @@ class Block(object):
 
         # Now we need to get the length of that list, and store that as a local variable
 
-        call_get_length_token = PyToken(
-            op=Opcode(pyop.CALL_FUNCTION), lineno=loopsetup.line_no, args=1)
+        call_get_length_token = PyToken(op=pyop.CALL_FUNCTION, lineno=loopsetup.line_no, args=1)
         call_get_length_token.func_params = [iterable_load]
         call_get_length_token.func_name = 'len'
 
@@ -414,8 +412,8 @@ class Block(object):
         self.iterable_looplength = 'forloop_length_%s' % Block.forloop_counter
 
         # now store the variable which is the output of the len(items) call
-        looplength_store_op = PyToken(op=Opcode(
-            pyop.STORE_FAST), lineno=loopsetup.line_no, index=-1, args=self.iterable_looplength)
+        looplength_store_op = PyToken(op=pyop.STORE_FAST,
+            lineno=loopsetup.line_no, index=-1, args=self.iterable_looplength)
 
         get_iter = self.oplist[2]
         for_iter = self.oplist[3]
@@ -425,16 +423,16 @@ class Block(object):
         # set the iterable variable name ( for example, i ) so that the loop body can use it
         self.iterable_variable = store_iterable_name.args
 
-        ld_loopcounter = PyToken(op=Opcode(
-            pyop.LOAD_FAST), lineno=loopsetup.line_no, index=-1, args=self.iterable_loopcounter)
+        ld_loopcounter = PyToken(op=pyop.LOAD_FAST,
+            lineno=loopsetup.line_no, index=-1, args=self.iterable_loopcounter)
 
-        ld_loop_length = PyToken(op=Opcode(
-            pyop.LOAD_FAST), lineno=loopsetup.line_no, index=-1, args=self.iterable_looplength)
+        ld_loop_length = PyToken(op=pyop.LOAD_FAST,
+            lineno=loopsetup.line_no, index=-1, args=self.iterable_looplength)
 
-        new__compare_op = PyToken(
-            op=Opcode(pyop.COMPARE_OP), lineno=loopsetup.line_no, index=-1, args='<')
-        new__popjump_op = PyToken(op=Opcode(
-            pyop.POP_JUMP_IF_FALSE), lineno=loopsetup.line_no, index=-1, args=for_iter.args)
+        new__compare_op = PyToken(op=pyop.COMPARE_OP,
+            lineno=loopsetup.line_no, index=-1, args=Compare.LT)
+        new__popjump_op = PyToken(op=pyop.POP_JUMP_IF_FALSE,
+            lineno=loopsetup.line_no, index=-1, args=for_iter.args)
 
         for_iter.args = None
 
@@ -487,37 +485,35 @@ class Block(object):
         #
 
         # load the iterable collection
-        ld_load_iterable = PyToken(op=Opcode(
-            pyop.LOAD_FAST), lineno=first_op.line_no, index=-1, args=setup_block.iterable_item_name)
+        ld_load_iterable = PyToken(op=pyop.LOAD_FAST,
+            lineno=first_op.line_no, index=-1, args=setup_block.iterable_item_name)
 
         # load the counter var
-        ld_counter = PyToken(op=Opcode(pyop.LOAD_FAST), lineno=first_op.line_no,
-                             index=-1, args=setup_block.iterable_loopcounter)
+        ld_counter = PyToken(op=pyop.LOAD_FAST,
+            lineno=first_op.line_no, index=-1, args=setup_block.iterable_loopcounter)
 
         # binary subscript of the iterable collection
-        ld_subscript = PyToken(op=Opcode(pyop.BINARY_SUBSCR),
-                               lineno=first_op.line_no, index=-1)
+        ld_subscript = PyToken(op=pyop.BINARY_SUBSCR, lineno=first_op.line_no, index=-1)
 
         # now store the iterated item
-        st_iterable = PyToken(op=Opcode(
-            pyop.STORE_FAST), lineno=first_op.line_no, index=-1, args=setup_block.iterable_variable)
+        st_iterable = PyToken(op=pyop.STORE_FAST,
+            lineno=first_op.line_no, index=-1, args=setup_block.iterable_variable)
 
         #
         # the following load the forloop counter and increments it
         #
 
         # load the counter var
-        ld_counter_2 = PyToken(op=Opcode(
-            pyop.LOAD_FAST), lineno=first_op.line_no, index=-1, args=setup_block.iterable_loopcounter)
+        ld_counter_2 = PyToken(op=pyop.LOAD_FAST,
+            lineno=first_op.line_no, index=-1, args=setup_block.iterable_loopcounter)
         # load the constant 1
-        increment_const = PyToken(
-            op=Opcode(pyop.LOAD_CONST), lineno=first_op.line_no, index=-1, args=1)
+        increment_const = PyToken(op=pyop.LOAD_CONST,
+            lineno=first_op.line_no, index=-1, args=1)
         # add it to the counter
-        increment_add = PyToken(
-            op=Opcode(pyop.INPLACE_ADD), lineno=first_op.line_no, index=-1)
+        increment_add = PyToken(op=pyop.INPLACE_ADD, lineno=first_op.line_no, index=-1)
         # and store it again
-        increment_store = PyToken(op=Opcode(
-            pyop.STORE_FAST), lineno=first_op.line_no, index=-1, args=setup_block.iterable_loopcounter)
+        increment_store = PyToken(op=pyop.STORE_FAST,
+            lineno=first_op.line_no, index=-1, args=setup_block.iterable_loopcounter)
 
         self.oplist = [
             ld_load_iterable, ld_counter, ld_subscript, st_iterable,
@@ -678,13 +674,13 @@ class Block(object):
                     changed_items = []
 
                     # load the array to set the item into
-                    ld_op = PyToken(Opcode(pyop.LOAD_FAST),
+                    ld_op = PyToken(pyop.LOAD_FAST,
                                     token.line_no, args=array_to_sub)
                     changed_items.append(ld_op)
 
                     # create the setitem op
-                    settoken = PyToken(Opcode(
-                        pyop.SETITEM), token.line_no, args=index_to_sub_at, array_item=item_to_sub)
+                    settoken = PyToken(pyop.SETITEM,
+                        token.line_no, args=index_to_sub_at, array_item=item_to_sub)
                     changed_items.append(settoken)
 
             if start_index_change is not None and end_index_change is not None:
@@ -724,9 +720,9 @@ class Block(object):
         tstart = self.oplist[:-1]
         tend = self.oplist[-1:]
 
-        newitems = [PyToken(Opcode(pyop.NOP), self.line),
+        newitems = [PyToken(pyop.NOP, self.line),
                     #                    PyToken(pyop.DROP_BODY, self.line),
-                    PyToken(Opcode(pyop.FROMALTSTACK), self.line),
-                    PyToken(Opcode(pyop.DROP), self.line)]
+                    PyToken(pyop.FROMALTSTACK, self.line),
+                    PyToken(pyop.DROP, self.line)]
 
         self.oplist = tstart + newitems + tend

--- a/boa/code/block.py
+++ b/boa/code/block.py
@@ -374,10 +374,10 @@ class Block(object):
 
         # load the value 0
         loopcounter_start_ld_const = PyToken(op=pyop.LOAD_CONST,
-            lineno=loopsetup.line_no, index=-1, args=0)
+                                             lineno=loopsetup.line_no, index=-1, args=0)
         # now store the loop counter
         loopcounter_store_fast = PyToken(op=pyop.STORE_FAST,
-            lineno=loopsetup.line_no, index=-1, args=self.iterable_loopcounter)
+                                         lineno=loopsetup.line_no, index=-1, args=self.iterable_loopcounter)
 
         # this loads the list that is going to be iterated over ( LOAD_FAST )
         # this will be removed... its added into the call get length token function params
@@ -413,7 +413,7 @@ class Block(object):
 
         # now store the variable which is the output of the len(items) call
         looplength_store_op = PyToken(op=pyop.STORE_FAST,
-            lineno=loopsetup.line_no, index=-1, args=self.iterable_looplength)
+                                      lineno=loopsetup.line_no, index=-1, args=self.iterable_looplength)
 
         get_iter = self.oplist[2]
         for_iter = self.oplist[3]
@@ -424,15 +424,15 @@ class Block(object):
         self.iterable_variable = store_iterable_name.args
 
         ld_loopcounter = PyToken(op=pyop.LOAD_FAST,
-            lineno=loopsetup.line_no, index=-1, args=self.iterable_loopcounter)
+                                 lineno=loopsetup.line_no, index=-1, args=self.iterable_loopcounter)
 
         ld_loop_length = PyToken(op=pyop.LOAD_FAST,
-            lineno=loopsetup.line_no, index=-1, args=self.iterable_looplength)
+                                 lineno=loopsetup.line_no, index=-1, args=self.iterable_looplength)
 
         new__compare_op = PyToken(op=pyop.COMPARE_OP,
-            lineno=loopsetup.line_no, index=-1, args=Compare.LT)
+                                  lineno=loopsetup.line_no, index=-1, args=Compare.LT)
         new__popjump_op = PyToken(op=pyop.POP_JUMP_IF_FALSE,
-            lineno=loopsetup.line_no, index=-1, args=for_iter.args)
+                                  lineno=loopsetup.line_no, index=-1, args=for_iter.args)
 
         for_iter.args = None
 
@@ -486,18 +486,18 @@ class Block(object):
 
         # load the iterable collection
         ld_load_iterable = PyToken(op=pyop.LOAD_FAST,
-            lineno=first_op.line_no, index=-1, args=setup_block.iterable_item_name)
+                                   lineno=first_op.line_no, index=-1, args=setup_block.iterable_item_name)
 
         # load the counter var
         ld_counter = PyToken(op=pyop.LOAD_FAST,
-            lineno=first_op.line_no, index=-1, args=setup_block.iterable_loopcounter)
+                             lineno=first_op.line_no, index=-1, args=setup_block.iterable_loopcounter)
 
         # binary subscript of the iterable collection
         ld_subscript = PyToken(op=pyop.BINARY_SUBSCR, lineno=first_op.line_no, index=-1)
 
         # now store the iterated item
         st_iterable = PyToken(op=pyop.STORE_FAST,
-            lineno=first_op.line_no, index=-1, args=setup_block.iterable_variable)
+                              lineno=first_op.line_no, index=-1, args=setup_block.iterable_variable)
 
         #
         # the following load the forloop counter and increments it
@@ -505,15 +505,15 @@ class Block(object):
 
         # load the counter var
         ld_counter_2 = PyToken(op=pyop.LOAD_FAST,
-            lineno=first_op.line_no, index=-1, args=setup_block.iterable_loopcounter)
+                               lineno=first_op.line_no, index=-1, args=setup_block.iterable_loopcounter)
         # load the constant 1
         increment_const = PyToken(op=pyop.LOAD_CONST,
-            lineno=first_op.line_no, index=-1, args=1)
+                                  lineno=first_op.line_no, index=-1, args=1)
         # add it to the counter
         increment_add = PyToken(op=pyop.INPLACE_ADD, lineno=first_op.line_no, index=-1)
         # and store it again
         increment_store = PyToken(op=pyop.STORE_FAST,
-            lineno=first_op.line_no, index=-1, args=setup_block.iterable_loopcounter)
+                                  lineno=first_op.line_no, index=-1, args=setup_block.iterable_loopcounter)
 
         self.oplist = [
             ld_load_iterable, ld_counter, ld_subscript, st_iterable,
@@ -680,7 +680,7 @@ class Block(object):
 
                     # create the setitem op
                     settoken = PyToken(pyop.SETITEM,
-                        token.line_no, args=index_to_sub_at, array_item=item_to_sub)
+                                       token.line_no, args=index_to_sub_at, array_item=item_to_sub)
                     changed_items.append(settoken)
 
             if start_index_change is not None and end_index_change is not None:

--- a/boa/code/items.py
+++ b/boa/code/items.py
@@ -1,4 +1,3 @@
-from byteplay3 import Opcode
 from boa.code.pytoken import PyToken
 
 import importlib
@@ -6,7 +5,9 @@ import binascii
 import sys
 import os
 
-from byteplay3 import Code, SetLinenoType
+from bytecode import SetLineno
+from bytecode import Bytecode
+from bytecode import Instr
 from boa.code import pyop
 
 from boa.code.line import Line
@@ -45,26 +46,26 @@ class Definition(Item):
         super(Definition, self).__init__(item_list)
 
         # this is a simple definition like a = 3
-        if len(self.items) == 3:
-            self.value = PyToken(self.items[1], 1, args=self.items[1][1])
-            self.attr = PyToken(self.items[2], 1, args=self.items[2][1])
+        if len(self.items) == 2:
+            self.value = PyToken(self.items[0], 1, args=self.items[0].arg)
+            self.attr = PyToken(self.items[1], 1, args=self.items[1].arg)
         # a method based definition linke ctx = GetContext
-        elif len(self.items) == 4:
+        elif len(self.items) == 3:
             self.is_method_call = True
-            self.attr = PyToken(self.items[-1], 1, args=self.items[-1][1])
-            self.value = PyToken(Opcode(pyop.LOAD_CONST), 1, args=7)
+            self.attr = PyToken(self.items[-1], 1, args=self.items[-1].arg)
+            self.value = PyToken(pyop.LOAD_CONST, 1, args=7)
             self.convert_class_call_to_block()
 
-        elif len(self.items) == 5:
+        elif len(self.items) == 4:
             if self.items[-1][0] == pyop.RETURN_VALUE:
                 self.items = self.items[:3]
-                self.value = PyToken(self.items[1], 1, args=self.items[1][1])
-                self.attr = PyToken(self.items[2], 1, args=self.items[2][1])
+                self.value = PyToken(self.items[1], 1, args=self.items[1].arg)
+                self.attr = PyToken(self.items[2], 1, args=self.items[2].arg)
 
         else:
 
             #            self.is_method_call=True
-            self.attr = PyToken(self.items[-1], 1, args=self.items[-1][1])
+            self.attr = PyToken(self.items[-1], 1, args=self.items[-1].arg)
 #            print("SOMETHING ELSE!")
 #            pdb.set_trace()
 
@@ -75,9 +76,9 @@ class Definition(Item):
         opitems = self.items[1:]
         current_line_num = 1
         blockitems = []
-        for i, (op, arg) in enumerate(opitems):
+        for i, instr in enumerate(opitems):
 
-            token = PyToken(op, current_line_num, i, arg)
+            token = PyToken(instr.opcode, current_line_num, i, instr.arg)
             blockitems.append(token)
 
         self.block = Block(blockitems)
@@ -100,7 +101,9 @@ class Action(Item):
 
         arguments = []
 
-        for i, (key, value) in enumerate(self.items.items):
+        for i, instr in enumerate(self.items.items):
+            key = instr.opcode
+            value = instr.arg
             if key == pyop.LOAD_CONST:
                 arguments.append(value)
             elif key == pyop.STORE_NAME:
@@ -205,14 +208,14 @@ class Import(Item):
 
         sys.path.append(self.file_path)
 
-        for i, (op, arg) in enumerate(self.items):
-            if op == pyop.IMPORT_NAME:
-                self.module_path = arg
-            elif op == pyop.STORE_NAME:
-                self.module_items_to_import.append(arg)
+        for i, instr in enumerate(self.items):
+            if instr.opcode == pyop.IMPORT_NAME:
+                self.module_path = instr.arg
+            elif instr.opcode == pyop.STORE_NAME:
+                self.module_items_to_import.append(instr.arg)
 #                print("SETTING MODALu nAme: %s " % self.module_name)
 
-            elif op == pyop.IMPORT_STAR:
+            elif instr.opcode == pyop.IMPORT_STAR:
                 self.module_items_to_import = ['STAR']
 
         self.is_system_module = False
@@ -262,7 +265,7 @@ class Klass(Item):
 
     methods = None
 
-    bp = None
+    bc = None
 
     module = None
 
@@ -304,19 +307,20 @@ class Klass(Item):
 
         """
 
-        for i, (op, arg) in enumerate(self.items):
+        for i, instr in enumerate(self.items):
 
             # if the item is a byteplay3 code object, it is a method
-            if type(arg) is Code:
-                self.bp = arg
+            if instr.arg.__class__.__name__ == 'code':
+                self.bc = Bytecode.from_code(instr.arg)
 
             # load name is called  to gather the class parent
-            if op == pyop.LOAD_NAME:
-                self.parent_name = arg
+            if instr.opcode == pyop.LOAD_NAME:
+                self.parent_name = instr.arg
 
             # this occurs to store the name of the class
-            if op == pyop.STORE_NAME:
-                self.name = arg
+            if instr.opcode == pyop.STORE_NAME:
+                self.name = instr.arg
+
 
         self.split_lines()
 
@@ -348,20 +352,18 @@ class Klass(Item):
         Split the list of lines in the module into a set of objects that can be interpreted.
         """
 
-        lineitem = None
-
-        for i, (op, arg) in enumerate(self.bp.code):
-
-            if isinstance(op, SetLinenoType):
-                if lineitem is not None:
-                    self.lines.append(Line(lineitem))
-
+        lineitem = []
+        lastline = None
+        for i, instr in enumerate(self.bc):
+            if lastline is None:
+                lastline = instr.lineno
+            if instr.lineno != lastline:
+                self.lines.append(Line(lineitem))
+                lastline = instr.lineno
                 lineitem = []
 
-            lineitem.append((op, arg))
-
-        if len(lineitem):
-            self.lines.append(Line(lineitem))
+            lineitem.append(instr)
+        self.lines.append(Line(lineitem))
 
     def __str__(self):
         return self.name

--- a/boa/code/items.py
+++ b/boa/code/items.py
@@ -310,7 +310,7 @@ class Klass(Item):
 
         for i, instr in enumerate(self.items):
 
-            # if the item is a byteplay3 code object, it is a method
+            # if the item is a code object, it is a method
             if instr.arg.__class__.__name__ == 'code':
                 self.bc = Bytecode.from_code(instr.arg)
 

--- a/boa/code/items.py
+++ b/boa/code/items.py
@@ -322,7 +322,6 @@ class Klass(Item):
             if instr.opcode == pyop.STORE_NAME:
                 self.name = instr.arg
 
-
         self.split_lines()
 
         for lineset in self.lines:

--- a/boa/code/items.py
+++ b/boa/code/items.py
@@ -73,10 +73,9 @@ class Definition(Item):
 
         from boa.code.block import Block
 
-        opitems = self.items[1:]
         current_line_num = 1
         blockitems = []
-        for i, instr in enumerate(opitems):
+        for i, instr in enumerate(self.items):
 
             token = PyToken(instr.opcode, current_line_num, i, instr.arg)
             blockitems.append(token)
@@ -129,7 +128,9 @@ class SmartContractAppCall(Item):
 
         arguments = []
 
-        for i, (key, value) in enumerate(self.items.items):
+        for i, instr in enumerate(self.items.items):
+            key = instr.opcode
+            value = instr.arg
             if key == pyop.LOAD_CONST:
                 arguments.append(value)
             elif key == pyop.STORE_NAME:

--- a/boa/code/line.py
+++ b/boa/code/line.py
@@ -1,5 +1,3 @@
-from byteplay3 import *
-
 from boa.code import pyop
 
 
@@ -19,8 +17,8 @@ class Line(object):
 
         :return:
         """
-        for i, (op, arg) in enumerate(self.items):
-            if op in [pyop.IMPORT_NAME, pyop.IMPORT_FROM, pyop.IMPORT_STAR]:
+        for i, instr in enumerate(self.items):
+            if instr.opcode in [pyop.IMPORT_NAME, pyop.IMPORT_FROM, pyop.IMPORT_STAR]:
                 return True
         return False
 
@@ -30,15 +28,15 @@ class Line(object):
 
         :return:
         """
-        is_correct_length = len(self.items) == 3 or len(self.items) == 5
-        is_storing_constant = self.items[1][0] == pyop.LOAD_CONST and self.items[2][0] == pyop.STORE_NAME
+        is_correct_length = len(self.items) == 2 or len(self.items) == 4
+        is_storing_constant = self.items[0].opcode == pyop.LOAD_CONST and self.items[1].opcode == pyop.STORE_NAME
         return is_correct_length and is_storing_constant
 
     @property
     def is_module_method_call(self):
 
         if not self.is_class:
-            return self.items[-2][0] == pyop.CALL_FUNCTION and self.items[-1][0] == pyop.STORE_NAME
+            return self.items[-2].opcode == pyop.CALL_FUNCTION and self.items[-1].opcode == pyop.STORE_NAME
         return False
 
     @property
@@ -51,7 +49,7 @@ class Line(object):
 
         """
         for item in self.items:
-            if item[0] == pyop.STORE_NAME and item[1] == '__doc__':
+            if item.opcode == pyop.STORE_NAME and item.arg == '__doc__':
                 return True
         return False
 
@@ -61,8 +59,8 @@ class Line(object):
 
         :return:
         """
-        for i, (op, arg) in enumerate(self.items):
-            if op == pyop.MAKE_FUNCTION:
+        for i, instr in enumerate(self.items):
+            if instr.opcode == pyop.MAKE_FUNCTION:
                 return True
         return False
 
@@ -72,8 +70,8 @@ class Line(object):
 
         :return:
         """
-        for i, (op, arg) in enumerate(self.items):
-            if op == pyop.LOAD_BUILD_CLASS:
+        for i, instr in enumerate(self.items):
+            if instr.opcode == pyop.LOAD_BUILD_CLASS:
                 return True
         return False
 
@@ -83,9 +81,9 @@ class Line(object):
 
         :return:
         """
-        for i, (op, arg) in enumerate(self.items):
-            if type(arg) is Code:
-                return arg
+        for i, instr in enumerate(self.items):
+            if instr.arg.__class__.__name__ == 'code':
+                return instr.arg
         return None
 
     @property
@@ -94,8 +92,8 @@ class Line(object):
 
         :return:
         """
-        for i, (op, arg) in enumerate(self.items):
-            if arg == 'RegisterAction':
+        for i, instr in enumerate(self.items):
+            if instr.arg == 'RegisterAction':
                 return True
 
     @property
@@ -104,6 +102,6 @@ class Line(object):
 
         :return:
         """
-        for i, (op, arg) in enumerate(self.items):
-            if arg == 'RegisterAppCall':
+        for i, instr in enumerate(self.items):
+            if instr.arg == 'RegisterAppCall':
                 return True

--- a/boa/code/method.py
+++ b/boa/code/method.py
@@ -127,10 +127,10 @@ class Method(object):
     @property
     def code(self):
         """
-        Return the ``byteplay3`` code object.
+        Return the ``bytecode`` code object.
 
-        :return: the ``byteplay3`` code object of this method
-        :rtype: ``byteplay3.Code``
+        :return: the ``Bytecode`` object of this method
+        :rtype: ``bytecode.Bytecode``
         """
 
         return self.bc
@@ -243,7 +243,7 @@ class Method(object):
 
     def print(self):
         """
-        This method prints the output of the method's ``byteplay3`` object 
+        This method prints the output of the method's ``Bytecode`` object 
         as it would be seen by a python interpreter.
         Compare this with the ``boa.code.method.Method.to_dis()`` output 
         and you will see subtle differences.
@@ -251,18 +251,10 @@ class Method(object):
         sample output:
 
         >>> method.print()
-              2            STORE_FAST           j
-              12         1 LOAD_CONST           9
-              14         4 LOAD_CONST           <byteplay3.Code object at 0x10cb5ec88>
-                         5 LOAD_CONST           'Main.<locals>.q'
-                         6 MAKE_FUNCTION        0
-                         7 STORE_FAST           q
-              22         9 LOAD_FAST            q
-                        10 LOAD_FAST            j
-                        11 CALL_FUNCTION        1
-                        12 STORE_FAST           m
-              24        14 LOAD_FAST            m
-                        15 RETURN_VALUE
+        [<LOAD_FAST arg='a' lineno=11>, <LOAD_FAST arg='b' lineno=11>, <BINARY_ADD
+        lineno=11>, <LOAD_FAST arg='c' lineno=11>, <LOAD_FAST arg='d'
+        lineno=11>, <BINARY_MULTIPLY lineno=11>, <BINARY_SUBTRACT lineno=11>,
+        <RETURN_VALUE lineno=11>]
         """
 
         print(self.code)
@@ -315,7 +307,7 @@ class Method(object):
 
     def read_initial_tokens(self):
         """
-        Take the initial set of tokens from the ``byteplay3`` code object and turn them into blocks.
+        Take the initial set of tokens from the ``Bytecode`` code object and turn them into blocks.
         """
 
         self.blocks = []
@@ -482,9 +474,6 @@ class Method(object):
         for t in self.tokens:
             tkn = t.to_vm(self.tokenizer, prevtoken)
             prevtoken = t
-
-        print(self.tokenizer.to_s())
-        print('------------')
 
     def convert_jumps(self):
         """

--- a/boa/code/method.py
+++ b/boa/code/method.py
@@ -11,9 +11,10 @@ import dis
 
 import collections
 
-CO_NEWLOCALS              = 0x0002      # only cleared for module/exec code
-CO_VARARGS                = 0x0004      # signature contains *arg
-CO_VARKEYWORDS            = 0x0008      # signature contains **kwargs
+CO_NEWLOCALS = 0x0002    # only cleared for module/exec code
+CO_VARARGS = 0x0004      # signature contains *arg
+CO_VARKEYWORDS = 0x0008  # signature contains **kwargs
+
 
 class Method(object):
     """
@@ -335,10 +336,10 @@ class Method(object):
 
             op = instr.opcode
             arg = instr.arg
+
             if arg is UNSET:
                 arg = None
             current_line_no = instr.lineno
-
 
             if instr.lineno != lastline:
                 total_lines += 1
@@ -352,32 +353,30 @@ class Method(object):
 
                 block_group = []
 
-            if 1==1:
-                if op in [pyop.STORE_FAST, pyop.STORE_NAME, pyop.STORE_GLOBAL] and arg not in self.local_stores.keys():
+            if op in [pyop.STORE_FAST, pyop.STORE_NAME, pyop.STORE_GLOBAL] and arg not in self.local_stores.keys():
 
-                    self._check_for_type(arg, total_lines)
-                    length = len(self.local_stores)
-                    self.local_stores[arg] = length
+                self._check_for_type(arg, total_lines)
+                length = len(self.local_stores)
+                self.local_stores[arg] = length
 
-                token = PyToken(op, current_line_no, i, arg)
+            token = PyToken(op, current_line_no, i, arg)
 
-                if op == pyop.SETUP_LOOP:
-                    token.args = None
-                    current_loop_token = token
+            if op == pyop.SETUP_LOOP:
+                token.args = None
+                current_loop_token = token
 
-                if op == pyop.BREAK_LOOP and current_loop_token is not None:
-                    token.args = current_loop_token.args
-                    current_loop_token = None
+            if op == pyop.BREAK_LOOP and current_loop_token is not None:
+                token.args = current_loop_token.args
+                current_loop_token = None
 
-                if current_label is not None:
-                    token.jump_label = current_label
-                    current_label = None
+            if current_label is not None:
+                token.jump_label = current_label
+                current_label = None
 
-                block_group.append(token)
+            block_group.append(token)
 
         if len(block_group):
             self.blocks.append(Block(block_group))
-
 
     def process_block_groups(self):
         """
@@ -447,7 +446,6 @@ class Method(object):
                         self.local_stores[localvar] = length
                 iter_setup_block = block
                 self.dynamic_iterator_count += 1
-
 
             # print("ADDED BLOCK %s " % [str(op) for op in block.oplist])
 

--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -30,7 +30,7 @@ class Module(object):
     which will in turn give you access to any other loaded modules contained in the default module.
 
 
-    Each module ( as well as each method object ) contains a reference to a ``byteplay3`` object, named ``bc``.
+    Each module ( as well as each method object ) contains a reference to a ``Bytecode`` object, named ``bc``.
     This object contains the instruction set as it would be viewed in the Python interpreter.
 
     You can call ``print(module.bc)`` on any object with a ``bc`` attribute, and it will output the Python interpreter code.
@@ -39,16 +39,13 @@ class Module(object):
     >>> from boa.compiler import Compiler
     >>> module = Compiler.load('./boa/tests/src/AddTest1.py').default
     >>> print(module.bc)
-    2     1 LOAD_CONST           <byteplay3.Code object at 0x10cc3d6a0>
-          2 LOAD_CONST           'Main'
-          3 MAKE_FUNCTION        0
-          4 STORE_NAME           Main
-          5 LOAD_CONST           None
-          6 RETURN_VALUE
+    [<LOAD_CONST arg=<code object Main at 0x7f97aa635660, file "./boa/tests/src/AddTest1.py", line 2> lineno=2>,
+    <LOAD_CONST arg='Main' lineno=2>, <MAKE_FUNCTION arg=0 lineno=2>, <STORE_NAME arg='Main' lineno=2>,
+    <LOAD_CONST arg=None lineno=2>, <RETURN_VALUE lineno=2>]
 
 
     Once an executable has been processed and tokenized, it will then have a set of vm tokens that are similar
-    to the ``byteplay3`` tokens, but different in important ways. These are contained in the module's ``all_vm_tokens`` attribute
+    to the ``Bytecode`` tokens, but different in important ways. These are contained in the module's ``all_vm_tokens`` attribute
 
     You may call ``module.to_s()`` to view the program as it has been tokenized for the NEO Virtual Machine.
 
@@ -84,7 +81,7 @@ class Module(object):
                   116 RETURN_VALUE                         [data]
     """
 
-    bc = None  # this is to store the byteplay reference
+    bc = None  # this is to store the Bytecode reference
 
     path = None  # the path where this file is
 
@@ -302,7 +299,7 @@ class Module(object):
 
     def process_method(self, lineset):
         """
-        processes a set of lines that contain a byteplay3 code object
+        processes a set of lines that contain a Bytecode object
 
         :param lineset: the lineset to process and add
         :type lineset: Line

--- a/boa/code/pytoken.py
+++ b/boa/code/pytoken.py
@@ -1,8 +1,9 @@
 from boa.code import pyop
 
-from byteplay3 import Label, isopcode, haslocal
+from bytecode.instr import Compare
+import bytecode
 
-from opcode import opname
+import opcode
 
 from boa.blockchain.vm import VMOp
 
@@ -64,18 +65,18 @@ class PyToken(object):
         :return:
         """
         if type(self.py_op) is int:
-            return opname[self.py_op]
-        elif type(self.py_op) is Label:
+            return opcode.opname[self.py_op]
+        elif type(self.py_op) is bytecode.Label:
             return 'Label %s ' % self.py_op
         return self.py_op
 
     @property
     def is_op(self):
         """
-
-        :return:
+        Return whether obj is an opcode - not SetLineno or Label
         """
-        return isopcode(self.py_op)
+
+        return not isinstance(self.py_op, bytecode.SetLineno) and not isinstance(self.py_op, bytecode.Label)
 
     @property
     def is_local(self):
@@ -83,7 +84,7 @@ class PyToken(object):
 
         :return:
         """
-        return haslocal(self.py_op)
+        return self.py_op in opcode.haslocal
 
     @property
     def arg_s(self):
@@ -109,7 +110,7 @@ class PyToken(object):
 
     def __str__(self):
         if self.args:
-            if type(self.args) is Label:
+            if type(self.args) is bytecode.Label:
                 arg = str(self.args)
             else:
                 arg = self.args
@@ -245,20 +246,19 @@ class PyToken(object):
             # compare
 
             elif op == pyop.COMPARE_OP:
-
-                if self.args == '>':
+                if self.args == Compare.GT:
                     token = tokenizer.convert1(VMOp.GT, self)
-                elif self.args == '>=':
+                elif self.args == Compare.GE:
                     token = tokenizer.convert1(VMOp.GTE, self)
-                elif self.args == '<':
+                elif self.args == Compare.LT:
                     token = tokenizer.convert1(VMOp.LT, self)
-                elif self.args == '<=':
+                elif self.args == Compare.LE:
                     token = tokenizer.convert1(VMOp.LTE, self)
-                elif self.args == '==':
+                elif self.args == Compare.EQ:
                     token = tokenizer.convert1(VMOp.NUMEQUAL, self)
-                elif self.args == 'is':
+                elif self.args == Compare.IS:
                     token = tokenizer.convert1(VMOp.EQUAL, self)
-                elif self.args == '!=':
+                elif self.args == Compare.NE:
                     token = tokenizer.convert1(VMOp.NUMNOTEQUAL, self)
 
             # arrays

--- a/boa/code/vmtoken.py
+++ b/boa/code/vmtoken.py
@@ -1,7 +1,7 @@
 import pdb
 from collections import OrderedDict
 from boa.code import pyop
-from byteplay3 import Label
+from bytecode import Label
 from boa.blockchain.vm import VMOp
 from boa.blockchain.vm.BigInteger import BigInteger
 

--- a/boa/tests/src/EventTest.py
+++ b/boa/tests/src/EventTest.py
@@ -1,4 +1,3 @@
-
 from boa.blockchain.vm.Neo.Action import RegisterAction
 
 

--- a/compare.py
+++ b/compare.py
@@ -1,0 +1,67 @@
+import os
+import sys
+from pprint import pprint
+
+from boa.compiler import Compiler
+from boa.compiler import Compiler as MyCompiler
+
+ORIGINAL_DIR = 'boa/tests/src/'
+NEW_DIR = 'myboa/tests/src/'
+
+def run_all():
+    total = 0
+    success = 0
+    error_list = []
+    for filename in sorted(os.listdir(ORIGINAL_DIR)):
+        if not filename.endswith('.py'):
+            continue
+        total += 1
+        try:
+            if run_one(filename):
+                success += 1
+            else:
+                error_list.append(filename)
+        except:
+            error_list.append(filename)
+            print('Error happened while processing :(')
+
+    print('{}% ({}/{}) passed!'.format(100*success/total, success, total))
+    if len(error_list):
+        print('These did not pass:')
+        pprint(error_list)
+
+def run_one(filename):
+    original_file = '{}{}'.format(ORIGINAL_DIR, filename)
+    new_file  = '{}{}'.format(NEW_DIR, filename)
+    original_avm = original_file.replace('.py', '.avm')
+    new_avm = new_file.replace('.py', '.avm')
+    print('Evaluating {}...'.format(filename))
+    module = Compiler.load_and_save(original_file)
+    print('      ')
+    print('======')
+    print('======')
+    print('======')
+    print('======')
+    print('      ')
+    myModule = MyCompiler.load_and_save(new_file)
+    f1 = open(original_avm, 'rb')
+    f2 = open(new_avm, 'rb')
+    original_avm_bytecode = f1.read()
+    new_avm_bytecode = f2.read()
+    f1.close()
+    f2.close()
+    if original_avm_bytecode != new_avm_bytecode:
+        print('Bytecodes do not match!')
+        print(original_avm_bytecode)
+        print(new_avm_bytecode)
+        return False
+    else:
+        print('Bytecodes match!')
+        return True
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        run_all()
+    else:
+        run_one(sys.argv[1])
+

--- a/compile.py
+++ b/compile.py
@@ -1,0 +1,38 @@
+import os
+import sys
+from pprint import pprint
+from boa.compiler import Compiler
+
+TEST_DIR = 'boa/tests/src/'
+
+def compile_all():
+    error_list = []
+    total = 0
+    success = 0
+    for filename in sorted(os.listdir(TEST_DIR)):
+        if not filename.endswith('.py'):
+            continue
+        total += 1
+        try:
+            compile_one(filename)
+            success += 1
+        except:
+            error_list.append(filename)
+            print('Error happened while processing :(')
+
+    print('{}% ({}/{}) compiled!'.format(100*success/total, success, total))
+    if len(error_list):
+        print('These had errors:')
+        pprint(error_list)
+
+def compile_one(filename):
+    filepath = '{}{}'.format(TEST_DIR, filename)
+    print('Compiling {}...'.format(filename))
+    module = Compiler.load_and_save(filepath)
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        compile_all()
+    else:
+        compile_one(sys.argv[1])
+

--- a/compile.py
+++ b/compile.py
@@ -9,16 +9,20 @@ def compile_all():
     error_list = []
     total = 0
     success = 0
-    for filename in sorted(os.listdir(TEST_DIR)):
-        if not filename.endswith('.py'):
-            continue
-        total += 1
-        try:
-            compile_one(filename)
-            success += 1
-        except:
-            error_list.append(filename)
-            print('Error happened while processing :(')
+    for folder in os.walk(TEST_DIR):
+        for filename in sorted(folder[2]):
+            relative_path = folder[0].replace(TEST_DIR, '')
+            if len(relative_path) > 0:
+                filename ='{}/{}'.format(relative_path,filename)
+            if not filename.endswith('.py'):
+                continue
+            total += 1
+            try:
+                compile_one(filename)
+                success += 1
+            except:
+                error_list.append(filename)
+                print('Error happened while processing :(')
 
     print('{}% ({}/{}) compiled!'.format(100*success/total, success, total))
     if len(error_list):

--- a/example.py
+++ b/example.py
@@ -1,0 +1,12 @@
+from boa.compiler import Compiler
+from boa.compiler import Compiler as MyCompiler
+
+#module = Compiler.load('boa/tests/src/AddTest1.py').default
+#print(module.bp.code)
+module = Compiler.load_and_save('boa/tests/src/AddTest1.py')
+
+print('-----------------')
+
+#myModule = MyCompiler.load('myboa/tests/src/AddTest1.py').default
+#print(myModule.bc)
+myModule = MyCompiler.load_and_save('myboa/tests/src/AddTest1.py')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ autopep8==1.3.3
 Babel==2.5.1
 blessings==1.6
 bpython==0.16
-byteplay3==3.5.0
+bytecode==0.5
 certifi==2017.7.27.1
 chardet==3.0.4
 CommonMark==0.5.4

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['byteplay3'],
+    install_requires=['bytecode'],
 
 
     python_requires='>=3.4, <3.6',


### PR DESCRIPTION
This PR is an important step towards python 3.6 (and onwards) compatibility.
It addresses #11, but doesn't close it yet as the **focus of this PR is only to replace** the [byteplay3](https://github.com/tallforasmurf/byteplay/) module with the [bytecode](https://github.com/vstinner/bytecode) module. Python 3.6 support will be tested and provided in another pull request.

To be 100% sure that switching the libraries didn't change `neo-boa` current behavior,  all files under `boa/code/tests/src` where tested for the same `.avm` output under the master branch and this branch.

There are a few improvements over the codebase that can be done now that `byteplay3` is gone, and maybe we can take advantage of [Control Flow Graph](https://bytecode.readthedocs.io/en/latest/cfg.html) to help the code evaluation. But again, the focus of this PR is to change the codebase as little as possible to only switch the libraries.
