### PR TITLE
Remove print_var import

### DIFF
--- a/boa/tests/src/Withdraw2Step.py
+++ b/boa/tests/src/Withdraw2Step.py
@@ -11,7 +11,7 @@ from boa.blockchain.vm.Neo.Output import GetScriptHash, GetValue, GetAssetId
 from boa.blockchain.vm.Neo.Input import GetHash, GetIndex
 from boa.blockchain.vm.Neo.Storage import GetContext, Get, Put, Delete
 
-from boa.code.builtins import range, concat, list, print_var
+from boa.code.builtins import range, concat, list
 
 OWNER = b'\xaf\x12\xa8h{\x14\x94\x8b\xc4\xa0\x08\x12\x8aU\nci[\xc1\xa5'
 


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
None

**What problem does this PR solve?**
Broken tests

**How did you solve this problem?**
By removing an import that was causing the problem, `print_var` was not defined in the imported module or anywhere else.
Also, it wasn't used anywhere in the file it was imported.

**How did you make sure your solution works?**
Running tests (now they pass).

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No
