### PR TITLE
Added missing missing module logzero in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,8 @@ RUN apt-get update && apt-get -y install python3-dev python3-pip
 
 RUN pip3 install neo-boa
 
+RUN pip3 install logzero
+
 COPY compiler.py /compiler.py
 
 CMD python3 compiler.py


### PR DESCRIPTION
**What current issue(s) from Github does this address?**

**What problem does this PR solve?**
It enables docker to work correctly.

**How did you solve this problem?**
I tried to use the docker but it complained that logzero module was missing.

**How did you make sure your solution works?**
I tested in my own machine. Since it is an independent docker image, it should work anywhere else.

**Are there any special changes in the code that we should be aware of?**
No.

**Is there anything else we should know?**
Perhaps this should be adoped in the official python package, but I don't know where it is, and how to inform that in a better place :)

