### PR TITLE
Added logzero to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ greenlet==0.4.12
 idna==2.6
 imagesize==0.7.1
 Jinja2==2.9.6
+logzero==1.4.0
 MarkupSafe==1.0
 pep8==1.7.0
 pkginfo==1.4.1


### PR DESCRIPTION
**What current issue(s) from Github does this address?**

**What problem does this PR solve?**
logzero dependency is missing, see file:  neo-boa/boa/code/pytoken.py

**How did you solve this problem?**
Followed the instructions to install neo-boa, installed logzero manually with pip, and included it with the corresponding version to the project.

**How did you make sure your solution works?**
I know this works because it works online at https://neocompiler.io

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

