### PR TITLE
Add missing logzero dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 astor>=0.6.2
 git+https://github.com/localhuman/bytecode.git@3eed8820e8379802c5f56a859bc6b239768a6aeb#egg=bytecode
+logzero==1.5.0


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
N/A

**What problem does this PR solve?**
Did a fresh install, was missing `logzero`

```
~/Documents/code/neo-boa/boa/code/pytoken.py in <module>()
      2 from boa.interop import VMOp
      3 from boa.code import pyop
----> 4 from logzero import logger
      5 import opcode
      6

ModuleNotFoundError: No module named 'logzero'
```

**How did you solve this problem?**
add it to requirements.txt

**How did you make sure your solution works?**
n/a

**Are there any special changes in the code that we should be aware of?**
no

**Is there anything else we should know?**
no
