### PR TITLE
Fix debug storage tests

### DIFF
--- a/boa_test/tests/test_contract.py
+++ b/boa_test/tests/test_contract.py
@@ -6,7 +6,7 @@ from boa.compiler import Compiler
 from neo.Prompt.Commands.BuildNRun import TestBuild
 import os
 import shutil
-
+from logzero import logger
 
 settings.USE_DEBUG_STORAGE = True
 settings.DEBUG_STORAGE_PATH = './fixtures/debugstorage'
@@ -17,12 +17,14 @@ class TestContract(BoaFixtureTest):
     @classmethod
     def tearDownClass(cls):
         super(BoaFixtureTest, cls).tearDownClass()
-
         try:
-            if os.path.exists(settings.DEBUG_STORAGE_PATH):
-                shutil.rmtree(settings.DEBUG_STORAGE_PATH)
+            if os.path.exists(settings.debug_storage_leveldb_path):
+
+                shutil.rmtree(settings.debug_storage_leveldb_path)
+            else:
+                logger.error("debug storage path doesn't exist")
         except Exception as e:
-            print("couldn't remove debug storage %s " % e)
+            logger.error("couldn't remove debug storage %s " % e)
 
     def test_Contract(self):
         output = Compiler.instance().load('%s/boa_test/example/blockchain/ContractTest.py' % TestContract.dirname).default

--- a/boa_test/tests/test_ico_template.py
+++ b/boa_test/tests/test_ico_template.py
@@ -12,6 +12,7 @@ from boa_test.example.demo.nex.token import *
 
 import shutil
 import os
+from logzero import logger
 
 settings.USE_DEBUG_STORAGE = True
 settings.DEBUG_STORAGE_PATH = './fixtures/debugstorage'
@@ -25,12 +26,14 @@ class TestContract(BoaFixtureTest):
     @classmethod
     def tearDownClass(cls):
         super(BoaFixtureTest, cls).tearDownClass()
-
         try:
-            if os.path.exists(settings.DEBUG_STORAGE_PATH):
-                shutil.rmtree(settings.DEBUG_STORAGE_PATH)
+            if os.path.exists(settings.debug_storage_leveldb_path):
+
+                shutil.rmtree(settings.debug_storage_leveldb_path)
+            else:
+                logger.error("debug storage path doesn't exist")
         except Exception as e:
-            print("couldn't remove debug storage %s " % e)
+            logger.error("couldn't remove debug storage %s " % e)
 
     @classmethod
     def setUpClass(cls):

--- a/boa_test/tests/test_storage.py
+++ b/boa_test/tests/test_storage.py
@@ -4,7 +4,7 @@ from boa.compiler import Compiler
 from neo.Prompt.Commands.BuildNRun import TestBuild
 import os
 import shutil
-
+from logzero import logger
 
 settings.USE_DEBUG_STORAGE = True
 settings.DEBUG_STORAGE_PATH = './fixtures/debugstorage'
@@ -15,12 +15,14 @@ class TestContract(BoaFixtureTest):
     @classmethod
     def tearDownClass(cls):
         super(BoaFixtureTest, cls).tearDownClass()
-
         try:
-            if os.path.exists(settings.DEBUG_STORAGE_PATH):
-                shutil.rmtree(settings.DEBUG_STORAGE_PATH)
+            if os.path.exists(settings.debug_storage_leveldb_path):
+
+                shutil.rmtree(settings.debug_storage_leveldb_path)
+            else:
+                logger.error("debug storage path doesn't exist")
         except Exception as e:
-            print("couldn't remove debug storage %s " % e)
+            logger.error("couldn't remove debug storage %s " % e)
 
     def test_Storage(self):
         output = Compiler.instance().load('%s/boa_test/example/blockchain/StorageTest.py' % TestContract.dirname).default

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 astor>=0.6.2
-git+https://github.com/localhuman/bytecode.git@3eed8820e8379802c5f56a859bc6b239768a6aeb#egg=bytecode
 logzero==1.5.0
+git+https://github.com/localhuman/bytecode.git@0.5.1#egg=bytecode

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,7 @@
 astor>=0.6.2
-git+https://github.com/localhuman/bytecode.git@3eed8820e8379802c5f56a859bc6b239768a6aeb#egg=bytecode
-git+https://github.com/CityOfZion/neo-python.git@feature-dict#egg=neo-python
+logzero==1.5.0
+git+https://github.com/localhuman/bytecode.git@0.5.1#egg=bytecode
+git+https://github.com/CityOfZion/neo-python.git@development#egg=neo-python
 Sphinx==1.6.4
 sphinx-rtd-theme==0.2.4
 sphinxcontrib-websupport==1.0.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
+logzero==1.5.0
 astor>=0.6.2
-git+https://github.com/localhuman/bytecode.git@3eed8820e8379802c5f56a859bc6b239768a6aeb#egg=bytecode
-git+https://github.com/CityOfZion/neo-python.git@feature-dict#egg=neo-python
+git+https://github.com/localhuman/bytecode.git@0.5.1#egg=bytecode
+git+https://github.com/CityOfZion/neo-python.git@development#egg=neo-python

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,13 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['bytecode'],
 
+
+    install_requires=[
+        'bytecode>=0.5.0',
+        'astor'
+    ],
+    dependency_links =['https://github.com/localhuman/bytecode/tarball/master#egg=bytecode-0.5.1'],
 
     python_requires='>=3.6',
 


### PR DESCRIPTION
update requirements, and fix tests that use debug storage to use `settings.debug_storage_leveldb_path`, closes issue #60 


**Is there anything else we should know?**

This will fix tests when run multiple times by allowing the debugstorage directory to be properly cleaned up.  Unfortunately until we can deploy another version to Pypi, you will need to manually clean up the `~/.neopython/fixtures/debugstorage` directory when running `make test` more than once.


