### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ docker build -t neo-boa .
 The neo-boa Docker container takes a directory on the host containing python smart contracts as an input and a directory to compile the .avm files to as an output. It can be executed like this:
 
 ```
-docker run -it -v /absolute/path/input_dir:/python-contracts -v /absolute/path/output_dir:/compiled-contracts neo-boa
+docker run -it --rm -v /absolute/path/input_dir:/python-contracts -v /absolute/path/output_dir:/compiled-contracts neo-boa
 ```
 
 The -v (volume) command maps the directories on the host to the directories within the container.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 RUN apt-get update && apt-get -y install python3-dev python3-pip
 
-RUN pip3 install neo-boa
+RUN pip3 install astor logzero coz-bytecode neo-boa
 
 COPY compiler.py /compiler.py
 

--- a/docker/compiler.py
+++ b/docker/compiler.py
@@ -10,5 +10,9 @@ for file in os.listdir(input_file_dir):
         input_file_path = os.path.join(input_file_dir, file)
         output_file = file_name + '.avm'
         output_file_path = os.path.join(output_file_dir, output_file)
-        Compiler.load_and_save(path=input_file_path, output_path=output_file_path)
-        print('Compiled ' + file)
+        try:
+            Compiler.load_and_save(path=input_file_path, output_path=output_file_path)
+            print(' \033[92mCompiled\t{}'.format(file))
+        except Exception as e:
+            print(' \033[93mFail\t\t{}\t{}'.format(file, e))
+


### PR DESCRIPTION
* Added python dependencies in Dockerfile.
Without these dependencies neo-boa won't work inside the container.

* Improve compiler.py script.
Now compiler script doesn't crash and stop on invalid files and will compile all source files.
```
> docker run -it --rm -v $(pwd)/sources:/python-contracts -v $(pwd)/compiled:/compiled-contracts neo-boa
 Compiled	ico_smartcontract.py
 Fail		bad-sc.py	module 'errno' has no attribute '__file__'
 Compiled	token.py

```

* Added `--rm` to Readme.
There is no need to keep container after the compilation.