### PR TITLE
Print error msg with file/linenumber/method during tokenization error

### DIFF
--- a/boa/code/expression.py
+++ b/boa/code/expression.py
@@ -282,8 +282,14 @@ class Expression(object):
         for index, instr in enumerate(self.updated_blocklist):
             if isinstance(instr, Instr):
                 ln = instr.lineno
-            token = PyToken(instr, self, index, ln)
-            token.to_vm(self.tokenizer, last_token)
+
+            try:
+                token = PyToken(instr, self, index, ln)
+                token.to_vm(self.tokenizer, last_token)
+            except Exception as e:
+                cm = self.container_method
+                print("ERROR: %s:%s in %s() with msg - %s" % (cm.module.path, cm.start_line_no + ln - 1, cm.name, str(e)))
+
             last_token = token
 
     def lookup_method_name(self, index):

--- a/boa/code/pytoken.py
+++ b/boa/code/pytoken.py
@@ -274,5 +274,5 @@ class PyToken():
 
         elif op == pyop.RAISE_VARARGS:
             pass
-#        else:
-#            logger.info("Op Not Converted: %s " % self.instruction.name)
+        else:
+            raise Exception("Op Not Converted %s" % self.instruction.name)

--- a/boa/code/vmtoken.py
+++ b/boa/code/vmtoken.py
@@ -224,6 +224,7 @@ class VMTokenizer(object):
             token = self.convert_push_integer(pytoken.args, pytoken)
         elif isinstance(pytoken.args, type(None)):
             token = self.convert_push_data(bytearray(0))
+        # TODO - process tuple
 #        elif type(pytoken.args) == Code:
 #            pass
         else:

--- a/boa/compiler.py
+++ b/boa/compiler.py
@@ -93,7 +93,7 @@ class Compiler(object):
             Compiler.load_and_save('path/to/your/file.py')
         """
 
-        compiler = Compiler.load(path)
+        compiler = Compiler.load(os.path.abspath(path))
         data = compiler.write()
         if output_path is None:
             fullpath = os.path.realpath(path)


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
During tokenization error, either through unsupported OP code or unparsed expression, the compiler generally prints very little information to help the user pinpoint the problem, leading to time spent finding the mystery line of code causing the error. 

**What problem does this PR solve?**
More descriptive error printing giving exact file and linenumber during tokenization error

**How did you solve this problem?**
Catching exceptions during tokenization and printing more descriptive information to pinpoint the problem. 

**How did you make sure your solution works?**
Creating python code that uses expressions not supported by neo-boa at the moment, ensuring the proper error message is printed and the correct line number

For example
```python
#!/usr/bin/env python3

# Can't return a tuple
def thing():
    return a, b

def Main():
    # No list unpacking
    a, b = [1, 2]
    # No all support
    all([True, False, True])
    # No list comprehensions
    [a**a for a in [1, 2, 3, 4]]
```
Would give the compilation errors
```
ERROR: /home/conor/neo-neo-neo/neo-boa/main.py:5 in thing() with msg - Op Not Converted BUILD_TUPLE
ERROR: /home/conor/neo-neo-neo/neo-boa/main.py:9 in Main() with msg - Op Not Converted ROT_TWO
ERROR: /home/conor/neo-neo-neo/neo-boa/main.py:11 in Main() with msg - [Compilation error] Built in all is not implemented
ERROR: /home/conor/neo-neo-neo/neo-boa/main.py:13 in Main() with msg - Could not load type <class 'code'> for item <code object <listcomp> at 0x7f06e10ce810, file "<ast>", line 7> 
ERROR: /home/conor/neo-neo-neo/neo-boa/main.py:13 in Main() with msg - Op Not Converted MAKE_FUNCTION
ERROR: /home/conor/neo-neo-neo/neo-boa/main.py:13 in Main() with msg - Could not load type <class 'tuple'> for item (1, 2, 3, 4) 
ERROR: /home/conor/neo-neo-neo/neo-boa/main.py:13 in Main() with msg - Op Not Converted GET_ITER
ERROR: /home/conor/neo-neo-neo/neo-boa/main.py:13 in Main() with msg - pop from empty list

```
This continues to work when following imports. 

I can gladly update this PR if there are any issues. 