### PR TITLE
despite what was written - list manipulation is not supported

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -54,23 +54,6 @@ For details, please see all samples in the ``example`` directory.
         x.reverse()
 
 
-- list manipulation (building slices) is supported.
-
-    .. code-block:: python
-
-        x = [1,2,46,56]
-        y = x[1:3]
-
-        # you must specify the end element of a slice, the following will not work
-        z = x[1:]
-
-        # instead, use this
-        z = x[1:len(x)]
-
-
-        # the -1 index of a list does also not work at the moment
-
-
 - Where possible, some of Python's ``__builtins__`` have been implemented in a custom way for the Neo Virtual Machine.
 
     .. code-block:: python


### PR DESCRIPTION
slice.py:
from boa.interop.Neo.Runtime import Log

def Main():
    x = [1, 2, 46, 56]
    y = x[1:3]
    Log(y[0])

build /smart-contracts/slice.py test 07 05 True False

result:

[E 180425 00:48:05 ExecutionEngine:934] COULD NOT EXECUTE OP (33): Not supported b'\x7f' SUBSTR
[E 180425 00:48:05 ExecutionEngine:935] Not supported
    Traceback (most recent call last):
      File "/neo-python/neo/VM/ExecutionEngine.py", line 926, in StepInto
        self.ExecuteOp(op, self.CurrentContext)
      File "/neo-python/neo/VM/ExecutionEngine.py", line 351, in ExecuteOp
        x = estack.Pop().GetByteArray()
      File "/neo-python/neo/VM/InteropService.py", line 194, in GetByteArray
        raise Exception("Not supported")
    Exception: Not supported
[E 180425 00:48:05 ExecutionEngine:934] COULD NOT EXECUTE OP (37): Invalid list operation b'z' ROLL
[E 180425 00:48:05 ExecutionEngine:935] Invalid list operation
    Traceback (most recent call last):
      File "/neo-python/neo/VM/ExecutionEngine.py", line 926, in StepInto
        self.ExecuteOp(op, self.CurrentContext)
      File "/neo-python/neo/VM/ExecutionEngine.py", line 309, in ExecuteOp
        estack.PushT(estack.Remove(n))
      File "/neo-python/neo/VM/RandomAccessStack.py", line 57, in Remove
        raise Exception("Invalid list operation")
    Exception: Invalid list operation


