### PR TITLE
add support for DUP_TOP_TWO, ROT_THREE, ROT_TWO py opcodes

### DIFF
--- a/boa/code/pyop.py
+++ b/boa/code/pyop.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+import opcode
 # the following are python opcodes taken from the `opcode` module
 # these have been constantized for easier access
 # these are the opcodes used by python

--- a/boa/code/pytoken.py
+++ b/boa/code/pytoken.py
@@ -296,6 +296,12 @@ class PyToken():
             # if is_action:
             #     tokenizer.convert1(VMOp.DROP, self)
 
+        elif op == pyop.DUP_TOP_TWO:
+            tokenizer.convert_dup_top_two(self)
+        elif op == pyop.ROT_THREE:
+            tokenizer.convert1(VMOp.ROT, self)
+        elif op == pyop.ROT_TWO:
+            tokenizer.convert1(VMOp.SWAP)
         elif op == pyop.RAISE_VARARGS:
             pass
         elif op == pyop.EXTENDED_ARG:

--- a/boa/code/vmtoken.py
+++ b/boa/code/vmtoken.py
@@ -203,6 +203,21 @@ class VMTokenizer(object):
 
         self.convert1(VMOp.PACK, py_token)
 
+    def convert_dup_top_two(self, py_token=None):
+        # a, b, c, d
+        # <- SWAP
+        # b, a, c, d
+        # <- DUP
+        # b, b, a, c, d
+        # <- ROT
+        # b, a, b, c, d
+        # <- OVER
+        # a, b, a, b, c, d
+        self.convert1(VMOp.SWAP, py_token)
+        self.convert1(VMOp.DUP, py_token)
+        self.convert1(VMOp.ROT, py_token)
+        self.convert1(VMOp.OVER, py_token)
+
     def convert_pop_jmp_if(self, pytoken):
         #                token = tokenizer.convert1(VMOp.JMPIF, self, data=bytearray(2))
         token = self.convert1(VMOp.JMPIF, pytoken, data=bytearray(2))


### PR DESCRIPTION
add support for DUP_TOP_TWO, ROT_THREE, ROT_TWO py opcodes

Before this change, the above python opcodes were not converted during compilation.  This PR fixes that.
