### PR TITLE
Update equality comparator for strings

### DIFF
--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -274,7 +274,10 @@ class Module(object):
                 target_method = self.method_by_name(vmtoken.target_method)
                 if target_method:
                     jump_len = target_method.address - vmtoken.addr
-                    vmtoken.data = jump_len.to_bytes(2, 'little', signed=True)
+                    if jump_len > -32767 and jump_len < 32767:
+                        vmtoken.data = jump_len.to_bytes(2, 'little', signed=True)
+                    else:
+                        vmtoken.data = jump_len.to_bytes(4, 'little', signed=True)
                 else:
                     raise Exception("Target method %s not found" % vmtoken.target_method)
 

--- a/boa/code/pytoken.py
+++ b/boa/code/pytoken.py
@@ -252,7 +252,7 @@ class PyToken():
             elif self.instruction.arg == Compare.LE:
                 tokenizer.convert1(VMOp.LTE, self)
             elif self.instruction.arg == Compare.EQ:
-                tokenizer.convert1(VMOp.NUMEQUAL, self)
+                tokenizer.convert1(VMOp.EQUAL, self)
             elif self.instruction.arg == Compare.IS:
                 tokenizer.convert1(VMOp.EQUAL, self)
             elif self.instruction.arg in [Compare.NE, Compare.IS_NOT]:

--- a/boa_test/example/EqualityTest2.py
+++ b/boa_test/example/EqualityTest2.py
@@ -1,0 +1,47 @@
+
+def Main(operation):
+
+    if operation == 1:
+        a = 'deploy'
+
+        b = bytearray(b'deploy\x00\x00')
+
+        return a == b
+
+    elif operation == 2:
+
+        a = 'deploy'
+
+        b = bytearray(b'deploy')
+
+        return a == b
+
+    elif operation == 3:
+
+        a = b'deploy'
+        b = 'deploy'
+        return a == b
+
+    elif operation == 4:
+
+        a = 0
+        b = False
+        return a == b
+
+    elif operation == 5:
+
+        a = 0
+        b = ''
+        return a == b
+
+    elif operation == 6:
+
+        a = False
+        b = ''
+        return a == b
+
+    elif operation == 7:
+
+        a = False
+        b = -1
+        return a == b

--- a/boa_test/example/blockchain/ExecutionEngineTest.py
+++ b/boa_test/example/blockchain/ExecutionEngineTest.py
@@ -4,7 +4,6 @@ from boa.interop.System.ExecutionEngine import *
 def Main(operation):
 
     if operation == 'executing_sh':
-
         return GetExecutingScriptHash()
 
     elif operation == 'script_container':

--- a/boa_test/tests/test_dict.py
+++ b/boa_test/tests/test_dict.py
@@ -3,9 +3,6 @@ from boa.compiler import Compiler
 from neo.Settings import settings
 from neo.Prompt.Commands.BuildNRun import TestBuild
 
-# settings.set_log_vm_instruction(True)
-# settings.log_smart_contract_events = True
-
 
 class TestContract(BoaTest):
 

--- a/boa_test/tests/test_dict_create.py
+++ b/boa_test/tests/test_dict_create.py
@@ -3,9 +3,6 @@ from boa.compiler import Compiler
 from neo.Settings import settings
 from neo.Prompt.Commands.BuildNRun import TestBuild
 
-# settings.set_log_vm_instruction(True)
-# settings.log_smart_contract_events = True
-
 
 class TestContract(BoaTest):
 

--- a/boa_test/tests/test_equality.py
+++ b/boa_test/tests/test_equality.py
@@ -1,0 +1,39 @@
+from boa_test.tests.boa_test import BoaTest
+from boa.compiler import Compiler
+from neo.Prompt.Commands.BuildNRun import TestBuild
+
+
+class TestContract(BoaTest):
+
+    def test_Equality(self):
+
+        output = Compiler.instance().load('%s/boa_test/example/EqualityTest2.py' % TestContract.dirname).default
+        out = output.write()
+
+        tx, results, total_ops, engine = TestBuild(out, [1], self.GetWallet1(), '', '07')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].GetBoolean(), False)
+
+        tx, results, total_ops, engine = TestBuild(out, [2], self.GetWallet1(), '', '07')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].GetBoolean(), True)
+
+        tx, results, total_ops, engine = TestBuild(out, [3], self.GetWallet1(), '', '07')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].GetBoolean(), True)
+
+        tx, results, total_ops, engine = TestBuild(out, [4], self.GetWallet1(), '', '07')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].GetBoolean(), True)
+
+        tx, results, total_ops, engine = TestBuild(out, [5], self.GetWallet1(), '', '07')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].GetBoolean(), True)
+
+        tx, results, total_ops, engine = TestBuild(out, [6], self.GetWallet1(), '', '07')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].GetBoolean(), True)
+
+        tx, results, total_ops, engine = TestBuild(out, [7], self.GetWallet1(), '', '07')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].GetBoolean(), False)

--- a/boa_test/tests/test_system.py
+++ b/boa_test/tests/test_system.py
@@ -13,15 +13,16 @@ class TestContract(BoaFixtureTest):
 
         tx, results, total_ops, engine = TestBuild(out, ['executing_sh'], self.GetWallet1(), '07', '05')
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].GetByteArray(), bytearray(b'"rGz\xda\x8d>\xe4K,Q`_\xcc\x87\xe0\x9f\xd9d\x17'))
+        self.assertEqual(results[0].GetByteArray(), bytearray(b'\x82\x13\x19\xd7\xfc\x87\xec\xa5\xae\x04\x91\xf60E\xd5\xac\x9a\x07\xe2\xb1'))
 
         tx, results, total_ops, engine = TestBuild(out, ['calling_sh'], self.GetWallet1(), '07', '05')
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].GetByteArray(), bytearray(b'\xff\x95\xd6\x94\xf9\xf7\xaf\xcd\xf5\xc0\xbfe\xedz\x1c\xb4.\xdd\xa1\xd3'))
+        print("results: %s " % results[0].GetByteArray())
+        self.assertEqual(results[0].GetByteArray(), bytearray(b'\xb6\xa9\xdf\xfe\x85o\xdb<\x04\x7f\xacW\xc6\xc1)\xdb\xc5|\x12\xaa'))
 
         tx, results, total_ops, engine = TestBuild(out, ['entry_sh'], self.GetWallet1(), '07', '05')
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].GetByteArray(), bytearray(b'\xc4\xf0\xf0\x18\xfe\x96e\xf2J\xe7j\xe0\xb0\tW\xc5\x1e.\x13t'))
+        self.assertEqual(results[0].GetByteArray(), bytearray(b'2\xdez&\xc4\xc2>\xcbQ0\xa3cJ\x8c\xbdjd\xe9\x8d\xed'))
 
         tx, results, total_ops, engine = TestBuild(out, ['script_container'], self.GetWallet1(), '07', '05')
         self.assertEqual(len(results), 1)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 astor>=0.6.2
 logzero==1.5.0
 coz-bytecode==0.5.1
-neo-python==0.6.8
+neo-python==0.7.7
 Sphinx==1.6.4
 sphinx-rtd-theme==0.2.4
 sphinxcontrib-websupport==1.0.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 logzero==1.5.0
 astor>=0.6.2
-git+https://github.com/CityOfZion/neo-python.git@feature-prompt-iargs#egg=neo-python
+neo-python==0.7.7
 coz-bytecode==0.5.1


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
- changes `==` to use `EQUAL` operator rather than `NUMEQUAL`

**How did you make sure your solution works?**
- added tests

**Are there any special changes in the code that we should be aware of?**
- no

