### PR TITLE
fix runtime test timestamp

### DIFF
--- a/boa_test/tests/test_runtime.py
+++ b/boa_test/tests/test_runtime.py
@@ -27,7 +27,7 @@ class TestContract(BoaFixtureTest):
 
         tx, results, total_ops, engine = TestBuild(out, ['get_time', 1], self.GetWallet1(), '0202', '02')
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].GetByteArray(), bytearray(b'\x01r\x04Z'))
+        self.assertEqual(results[0].GetByteArray(), bytearray(b'\x10r\x04Z'))
 
         tx, results, total_ops, engine = TestBuild(out, ['check_witness', bytearray(b'S\xefB\xc8\xdf!^\xbeZ|z\xe8\x01\xcb\xc3\xac/\xacI)')], self.GetWallet1(), '02', '02')
         self.assertEqual(len(results), 1)


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
None
**What problem does this PR solve?**
there's a 15s difference caused by this check in neo-python: https://github.com/CityOfZion/neo-python/blob/master/neo/SmartContract/StateReader.py#L399-L400

which doesn't exist in the C# version https://github.com/neo-project/neo/blob/077bb5a4e2073c78a628a2a77617644a7f6fa21d/neo/SmartContract/StateReader.cs#L171

**How did you solve this problem?**
update expected return value

**How did you make sure your solution works?**
ran the test

**Are there any special changes in the code that we should be aware of?**
no

**Is there anything else we should know?**
no
