### PR TITLE
Update testcase when shifting BigInteger with a negative value

### DIFF
--- a/boa_test/tests/test_binops.py
+++ b/boa_test/tests/test_binops.py
@@ -46,8 +46,9 @@ class TestContract(BoaTest):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 64)
 
-        tx, results, total_ops, engine = TestBuild(out, ['<<', 16, -2], self.GetWallet1(), '', '07')
-        self.assertEqual(len(results), 0)
+        with self.assertRaises(ValueError) as context:
+            tx, results, total_ops, engine = TestBuild(out, ['<<', 16, -2], self.GetWallet1(), '', '07')
+        self.assertTrue("negative shift count" in str(context.exception))
 
         tx, results, total_ops, engine = TestBuild(out, ['<<', 4, 5], self.GetWallet1(), '', '07')
         self.assertEqual(len(results), 1)


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
For the ultimate goal of adding `BigInteger` checks in `neo-python`'s `ApplicationEngine` according to this [C# ref](https://github.com/neo-project/neo/blob/807d0e439740074e8be8809ac265357f760d30ef/neo/SmartContract/ApplicationEngine.cs#L163-L189) I had to add logical shift dunder methods to the `BigInteger` class [neo-python-core pr](https://github.com/CityOfZion/neo-python-core/pull/81).

In order to now get the tests to pass I had to update the above test.
 
**What problem does this PR solve?**
passing tests when updating `BigInteger` class

**How did you solve this problem?**
test for expected exception 

**How did you make sure your solution works?**
make test on whole `neo-python` build that includes `-core` and `-boa`

**Are there any special changes in the code that we should be aware of?**
no
**Is there anything else we should know?**
I need your help with doing a release such that `neo-python-core` builds pass so that the above PR can be merged
