### PR TITLE
update to support new neo-python release

### DIFF
--- a/boa_test/tests/boa_test.py
+++ b/boa_test/tests/boa_test.py
@@ -1,6 +1,6 @@
 from neo.Implementations.Wallets.peewee.UserWallet import UserWallet
 from neo.Settings import settings
-from neocore.UInt160 import UInt160
+from neo.Core.UInt160 import UInt160
 from neo.Wallets.utils import to_aes_key
 import os
 from neo.Utils.WalletFixtureTestCase import WalletFixtureTestCase

--- a/boa_test/tests/test_ico_template.py
+++ b/boa_test/tests/test_ico_template.py
@@ -7,7 +7,7 @@ from neo.SmartContract.SmartContractEvent import SmartContractEvent, NotifyEvent
 from neo.Settings import settings
 from neo.Prompt.Utils import parse_param
 from neo.Core.FunctionCode import FunctionCode
-from neocore.Fixed8 import Fixed8
+from neo.Core.Fixed8 import Fixed8
 from boa_test.example.demo.token.crowdsale import *
 from boa_test.example.demo.token.nep5 import *
 

--- a/boa_test/tests/test_ico_template.py
+++ b/boa_test/tests/test_ico_template.py
@@ -10,6 +10,7 @@ from neo.Core.FunctionCode import FunctionCode
 from neo.Core.Fixed8 import Fixed8
 from boa_test.example.demo.token.crowdsale import *
 from boa_test.example.demo.token.nep5 import *
+from neo.Blockchain import GetBlockchain
 
 import shutil
 import os
@@ -23,6 +24,8 @@ class TestContract(BoaFixtureTest):
 
     dispatched_events = []
     dispatched_logs = []
+
+    snapshot = None
 
     @classmethod
     def tearDownClass(cls):
@@ -50,6 +53,7 @@ class TestContract(BoaFixtureTest):
             cls.dispatched_logs.append(evt)
         events.on(SmartContractEvent.RUNTIME_NOTIFY, on_notif)
         events.on(SmartContractEvent.RUNTIME_LOG, on_log)
+        cls.snapshot = GetBlockchain()._db.createSnapshot()
 
     def test_ICOTemplate_1(self):
 
@@ -57,47 +61,49 @@ class TestContract(BoaFixtureTest):
         out = output.write()
 #        print(output.to_s())
 
-        tx, results, total_ops, engine = TestBuild(out, ['name', '[]'], self.GetWallet1(), '0705', '05')
+        snapshot = self.snapshot
+
+        tx, results, total_ops, engine = TestBuild(out, ['name', '[]'], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetString(), TOKEN_NAME)
 
-        tx, results, total_ops, engine = TestBuild(out, ['symbol', '[]'], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['symbol', '[]'], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetString(), TOKEN_SYMBOL)
 
-        tx, results, total_ops, engine = TestBuild(out, ['decimals', '[]'], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['decimals', '[]'], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), TOKEN_DECIMALS)
 
-        tx, results, total_ops, engine = TestBuild(out, ['totalSupply', '[]'], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['totalSupply', '[]'], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), TOKEN_TOTAL_SUPPLY)
 
-        tx, results, total_ops, engine = TestBuild(out, ['nonexistentmethod', '[]'], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['nonexistentmethod', '[]'], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetString(), 'unknown operation')
 
         # deploy with wallet 2 should fail CheckWitness
-        tx, results, total_ops, engine = TestBuild(out, ['deploy', '[]'], self.GetWallet2(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['deploy', '[]'], self.GetWallet2(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 
-        tx, results, total_ops, engine = TestBuild(out, ['deploy', '[]'], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['deploy', '[]'], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), True)
 
         # second time, it should already be deployed and return false
-        tx, results, total_ops, engine = TestBuild(out, ['deploy', '[]'], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['deploy', '[]'], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 
         # now circulation should be equal to the initial owner amount
-        tx, results, total_ops, engine = TestBuild(out, ['circulation', '[]'], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['circulation', '[]'], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), TOKEN_INITIAL_AMOUNT)
 
         # now the owner should have a balance of the TOKEN_INITIAL_AMOUNT
-        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param([bytearray(TOKEN_OWNER)])], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param([bytearray(TOKEN_OWNER)])], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), TOKEN_INITIAL_AMOUNT)
 
@@ -106,12 +112,13 @@ class TestContract(BoaFixtureTest):
         output = Compiler.instance().load('%s/boa_test/example/demo/ICO_Template.py' % TestContract.dirname).default
         out = output.write()
 
+        snapshot = self.snapshot
         # now transfer tokens to wallet 2
 
         TestContract.dispatched_events = []
 
         test_transfer_amount = 2400000001
-        tx, results, total_ops, engine = TestBuild(out, ['transfer', parse_param([bytearray(TOKEN_OWNER), self.wallet_2_script_hash.Data, test_transfer_amount])], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['transfer', parse_param([bytearray(TOKEN_OWNER), self.wallet_2_script_hash.Data, test_transfer_amount])], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), True)
 
@@ -123,37 +130,37 @@ class TestContract(BoaFixtureTest):
         self.assertEqual(evt.amount, test_transfer_amount)
 
         # now get balance of wallet 2
-        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param([self.wallet_2_script_hash.Data])], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param([self.wallet_2_script_hash.Data])], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), test_transfer_amount)
 
         # now the owner should have less
-        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param([bytearray(TOKEN_OWNER)])], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param([bytearray(TOKEN_OWNER)])], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), TOKEN_INITIAL_AMOUNT - test_transfer_amount)
 
         # now this transfer should fail
-        tx, results, total_ops, engine = TestBuild(out, ['transfer', parse_param([bytearray(TOKEN_OWNER), self.wallet_2_script_hash.Data, TOKEN_INITIAL_AMOUNT])], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['transfer', parse_param([bytearray(TOKEN_OWNER), self.wallet_2_script_hash.Data, TOKEN_INITIAL_AMOUNT])], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 
         # this transfer should fail because it is not signed by the 'from' address
-        tx, results, total_ops, engine = TestBuild(out, ['transfer', parse_param([bytearray(TOKEN_OWNER), self.wallet_2_script_hash.Data, 10000])], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['transfer', parse_param([bytearray(TOKEN_OWNER), self.wallet_2_script_hash.Data, 10000])], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 
         # now this transfer should fail, this is from address with no tokens
-        tx, results, total_ops, engine = TestBuild(out, ['transfer', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 1000])], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['transfer', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 1000])], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 
         # get balance of bad data
-        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param(['abc'])], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param(['abc'])], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 0)
 
         # get balance no params
-        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param([])], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param([])], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 
@@ -167,25 +174,27 @@ class TestContract(BoaFixtureTest):
 
         TestContract.dispatched_events = []
 
+        snapshot = self.snapshot
+
         # test mint tokens without being kyc verified
-        tx, results, total_ops, engine = TestBuild(out, ['mintTokens', '[]', '--attach-neo=10'], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['mintTokens', '[]', '--attach-neo=10'], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 
         # Try to register as a non owner
-        tx, results, total_ops, engine = TestBuild(out, ['crowdsale_register', parse_param([self.wallet_3_script_hash.Data])], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['crowdsale_register', parse_param([self.wallet_3_script_hash.Data])], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 
         # Get status of non registered address
-        tx, results, total_ops, engine = TestBuild(out, ['crowdsale_status', parse_param([self.wallet_3_script_hash.Data])], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['crowdsale_status', parse_param([self.wallet_3_script_hash.Data])], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 
         TestContract.dispatched_events = []
 
         # register an address
-        tx, results, total_ops, engine = TestBuild(out, ['crowdsale_register', parse_param([self.wallet_3_script_hash.Data])], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['crowdsale_register', parse_param([self.wallet_3_script_hash.Data])], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 1)
 
@@ -195,12 +204,12 @@ class TestContract(BoaFixtureTest):
         self.assertEqual(evt.event_payload.Value[0].Value, b'kyc_registration')
 
         # register 2 addresses at once
-        tx, results, total_ops, engine = TestBuild(out, ['crowdsale_register', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data])], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['crowdsale_register', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data])], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 2)
 
         # now check reg status
-        tx, results, total_ops, engine = TestBuild(out, ['crowdsale_status', parse_param([self.wallet_3_script_hash.Data])], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['crowdsale_status', parse_param([self.wallet_3_script_hash.Data])], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), True)
 
@@ -209,8 +218,10 @@ class TestContract(BoaFixtureTest):
         output = Compiler.instance().load('%s/boa_test/example/demo/ICO_Template.py' % TestContract.dirname).default
         out = output.write()
 
+        snapshot = self.snapshot
+
         # test mint tokens without being kyc verified
-        tx, results, total_ops, engine = TestBuild(out, ['get_attachments', '[]', '--attach-neo=10'], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['get_attachments', '[]', '--attach-neo=10'], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         attachments = results[0].GetArray()
         self.assertEqual(len(attachments), 4)
@@ -222,7 +233,7 @@ class TestContract(BoaFixtureTest):
         self.assertEqual(attachments[2].GetBigInteger(), Fixed8.FromDecimal(10).value)
         self.assertEqual(attachments[3].GetBigInteger(), 0)
 
-        tx, results, total_ops, engine = TestBuild(out, ['get_attachments', '[]'], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['get_attachments', '[]'], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         attachments = results[0].GetArray()
         self.assertEqual(len(attachments), 4)
@@ -231,7 +242,7 @@ class TestContract(BoaFixtureTest):
         self.assertEqual(attachments[2].GetBigInteger(), 0)
         self.assertEqual(attachments[3].GetBigInteger(), 0)
 
-        tx, results, total_ops, engine = TestBuild(out, ['get_attachments', '[]', '--attach-neo=3', '--attach-gas=3.12'], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['get_attachments', '[]', '--attach-neo=3', '--attach-gas=3.12'], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         attachments = results[0].GetArray()
         self.assertEqual(len(attachments), 4)
@@ -244,15 +255,17 @@ class TestContract(BoaFixtureTest):
         output = Compiler.instance().load('%s/boa_test/example/demo/ICO_Template.py' % TestContract.dirname).default
         out = output.write()
 
+        snapshot = self.snapshot
+
         # register an address
-        tx, results, total_ops, engine = TestBuild(out, ['crowdsale_register', parse_param([self.wallet_3_script_hash.Data])], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['crowdsale_register', parse_param([self.wallet_3_script_hash.Data])], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 1)
 
         TestContract.dispatched_events = []
 
         # test mint tokens, this should return true
-        tx, results, total_ops, engine = TestBuild(out, ['mintTokens', '[]', '--attach-neo=10'], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['mintTokens', '[]', '--attach-neo=10'], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), True)
 
@@ -264,17 +277,17 @@ class TestContract(BoaFixtureTest):
         self.assertEqual(evt.addr_to, self.wallet_3_script_hash)
 
         # test mint tokens again, this should be false since you can't do it twice
-        tx, results, total_ops, engine = TestBuild(out, ['mintTokens', '[]', '--attach-neo=10'], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['mintTokens', '[]', '--attach-neo=10'], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 
         # now the minter should have a balance
-        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param([self.wallet_3_script_hash.Data])], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param([self.wallet_3_script_hash.Data])], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 10 * TOKENS_PER_NEO)
 
         # now the total circulation should be bigger
-        tx, results, total_ops, engine = TestBuild(out, ['circulation', '[]'], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['circulation', '[]'], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), (10 * TOKENS_PER_NEO) + TOKEN_INITIAL_AMOUNT)
 
@@ -283,30 +296,32 @@ class TestContract(BoaFixtureTest):
         output = Compiler.instance().load('%s/boa_test/example/demo/ICO_Template.py' % TestContract.dirname).default
         out = output.write()
 
+        snapshot = self.snapshot
+
         # tranfer_from, approve, allowance
-        tx, results, total_ops, engine = TestBuild(out, ['allowance', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data])], self.GetWallet2(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['allowance', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data])], self.GetWallet2(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 0)
 
         # try to transfer from
-        tx, results, total_ops, engine = TestBuild(out, ['transferFrom', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 10000])], self.GetWallet2(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['transferFrom', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 10000])], self.GetWallet2(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 
         # try to approve from someone not yourself
-        tx, results, total_ops, engine = TestBuild(out, ['approve', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 10000])], self.GetWallet2(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['approve', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 10000])], self.GetWallet2(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 0)
 
         # try to approve more than you have
-        tx, results, total_ops, engine = TestBuild(out, ['approve', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, TOKEN_INITIAL_AMOUNT])], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['approve', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, TOKEN_INITIAL_AMOUNT])], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 0)
 
         TestContract.dispatched_events = []
 
         # approve should work
-        tx, results, total_ops, engine = TestBuild(out, ['approve', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 1234])], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['approve', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 1234])], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), True)
 
@@ -318,43 +333,43 @@ class TestContract(BoaFixtureTest):
         self.assertEqual(evt.amount, 1234)
 
         # check allowance
-        tx, results, total_ops, engine = TestBuild(out, ['allowance', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data])], self.GetWallet2(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['allowance', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data])], self.GetWallet2(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 1234)
 
         # approve should not be additive, it should overwrite previous approvals
-        tx, results, total_ops, engine = TestBuild(out, ['approve', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 133234])], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['approve', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 133234])], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), True)
 
-        tx, results, total_ops, engine = TestBuild(out, ['allowance', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data])], self.GetWallet2(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['allowance', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data])], self.GetWallet2(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 133234)
 
         # now you can transfer from
-        tx, results, total_ops, engine = TestBuild(out, ['transferFrom', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 10000])], self.GetWallet2(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['transferFrom', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 10000])], self.GetWallet2(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), True)
 
         # now the recevier should have a balance
         # it is equal to 10000 plus test_transfer_amount = 2400000001
 
-        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param([self.wallet_2_script_hash.Data])], self.GetWallet1(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['balanceOf', parse_param([self.wallet_2_script_hash.Data])], self.GetWallet1(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 10000 + 2400000001)
 
         # now the allowance should be less
-        tx, results, total_ops, engine = TestBuild(out, ['allowance', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data])], self.GetWallet2(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['allowance', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data])], self.GetWallet2(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 133234 - 10000)
 
         # try to transfer too much, even with approval
-        tx, results, total_ops, engine = TestBuild(out, ['transferFrom', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 14440000])], self.GetWallet2(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['transferFrom', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, 14440000])], self.GetWallet2(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 
         # cant approve negative amounts
-        tx, results, total_ops, engine = TestBuild(out, ['approve', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, -1000])], self.GetWallet3(), '0705', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['approve', parse_param([self.wallet_3_script_hash.Data, self.wallet_2_script_hash.Data, -1000])], self.GetWallet3(), '0705', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBoolean(), False)
 

--- a/boa_test/tests/test_serialization.py
+++ b/boa_test/tests/test_serialization.py
@@ -1,7 +1,7 @@
 from boa_test.tests.boa_test import BoaTest
 from boa.compiler import Compiler
 from neo.VM.InteropService import StackItem, Array, ByteArray
-from neocore.IO.BinaryReader import BinaryReader
+from neo.Core.IO.BinaryReader import BinaryReader
 from neo.IO.MemoryStream import StreamManager
 from neo.Prompt.Commands.BuildNRun import TestBuild
 

--- a/boa_test/tests/test_storage.py
+++ b/boa_test/tests/test_storage.py
@@ -5,6 +5,7 @@ from neo.Prompt.Commands.BuildNRun import TestBuild
 import os
 import shutil
 from logzero import logger
+from neo.Blockchain import GetBlockchain
 
 settings.USE_DEBUG_STORAGE = True
 settings.DEBUG_STORAGE_PATH = './fixtures/debugstorage'
@@ -28,23 +29,25 @@ class TestContract(BoaFixtureTest):
         output = Compiler.instance().load('%s/boa_test/example/blockchain/StorageTest.py' % TestContract.dirname).default
         out = output.write()
 
-        tx, results, total_ops, engine = TestBuild(out, ['sget', 'something', 'blah'], self.GetWallet1(), '070505', '05')
+        snapshot = GetBlockchain()._db.createSnapshot()
+
+        tx, results, total_ops, engine = TestBuild(out, ['sget', 'something', 'blah'], self.GetWallet1(), '070505', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetByteArray(), b'')
 
-        tx, results, total_ops, engine = TestBuild(out, ['sput', 'something', 'blah'], self.GetWallet1(), '070505', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['sput', 'something', 'blah'], self.GetWallet1(), '070505', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetByteArray(), b'\x01')
 
-        tx, results, total_ops, engine = TestBuild(out, ['sget', 'something', 'blah'], self.GetWallet1(), '070505', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['sget', 'something', 'blah'], self.GetWallet1(), '070505', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetByteArray(), b'blah')
 
-        tx, results, total_ops, engine = TestBuild(out, ['sdel', 'something', 'blah'], self.GetWallet1(), '070505', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['sdel', 'something', 'blah'], self.GetWallet1(), '070505', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetByteArray(), b'\x01')
 
-        tx, results, total_ops, engine = TestBuild(out, ['sget', 'something', 'blah'], self.GetWallet1(), '070505', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['sget', 'something', 'blah'], self.GetWallet1(), '070505', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetByteArray(), b'')
 
@@ -52,22 +55,24 @@ class TestContract(BoaFixtureTest):
         output = Compiler.instance().load('%s/boa_test/example/blockchain/StorageTest.py' % TestContract.dirname).default
         out = output.write()
 
-        tx, results, total_ops, engine = TestBuild(out, ['sget', 100, 10000000000], self.GetWallet1(), '070505', '05')
+        snapshot = GetBlockchain()._db.createSnapshot()
+
+        tx, results, total_ops, engine = TestBuild(out, ['sget', 100, 10000000000], self.GetWallet1(), '070505', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetByteArray(), b'')
 
-        tx, results, total_ops, engine = TestBuild(out, ['sput', 100, 10000000000], self.GetWallet1(), '070505', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['sput', 100, 10000000000], self.GetWallet1(), '070505', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetByteArray(), b'\x01')
 
-        tx, results, total_ops, engine = TestBuild(out, ['sget', 100, 10000000000], self.GetWallet1(), '070505', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['sget', 100, 10000000000], self.GetWallet1(), '070505', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetBigInteger(), 10000000000)
 
-        tx, results, total_ops, engine = TestBuild(out, ['sdel', 100, 10000000000], self.GetWallet1(), '070505', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['sdel', 100, 10000000000], self.GetWallet1(), '070505', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetByteArray(), b'\x01')
 
-        tx, results, total_ops, engine = TestBuild(out, ['sget', 100, 10000000000], self.GetWallet1(), '070505', '05')
+        tx, results, total_ops, engine = TestBuild(out, ['sget', 100, 10000000000], self.GetWallet1(), '070505', '05', snapshot=snapshot)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].GetByteArray(), b'')

--- a/boa_test/tests/test_tx.py
+++ b/boa_test/tests/test_tx.py
@@ -91,7 +91,7 @@ class TestContract(BoaFixtureTest):
 
         tx, results, total_ops, engine = TestBuild(out, ['get_type', txid], self.GetWallet1(), '07', '05')
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].GetByteArray(), bytearray(b'\x80'))
+        self.assertEqual(results[0].GetByteArray(), bytearray(b'\x80\x00'))
 
         tx, results, total_ops, engine = TestBuild(out, ['get_attrs', txid], self.GetWallet1(), '07', '05')
         self.assertEqual(len(results), 1)


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
`neo-boa` uses `neocore` imports that are made available upon installation of `neo-python`. We've deprecated `neo-python-core` with https://github.com/CityOfZion/neo-python/pull/925
We points the imports to the new location.

**What problem does this PR solve?**
^^
**How did you solve this problem?**
change imports

**How did you make sure your solution works?**
make test
**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

