### PR TITLE
Add support for compiling contract without needing file

### DIFF
--- a/boa/compiler.py
+++ b/boa/compiler.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from boa.code.module import Module
 
 
@@ -75,6 +76,18 @@ class Compiler(object):
         out_bytes = bytes(self.entry_module.write())
         return out_bytes
 
+    def write_contract(self):
+        """
+        Write the default module to avm bytecode.
+
+        :return: the compiled Python program as a byte string
+        :rtype: string
+        """
+
+        avm = self.entry_module.write()
+        return avm.hex()
+
+
     @staticmethod
     def load_and_save(path, output_path=None, use_nep8=True):
         """
@@ -130,4 +143,25 @@ class Compiler(object):
         compiler.nep8 = use_nep8
         compiler.entry_module = Module(path)
 
+        return compiler
+
+    @staticmethod
+    def load_contract(contract, use_nep8=True):
+        """
+        Call `load_contract` to load a contract as a variable to be compiled to .avm
+
+        :param contract: the raw python code
+        :return: The instance of the compiler
+
+        .. code-block:: python
+
+            from boa.compiler import Compiler
+
+            compiler = Compiler.load_contract("def Main(): ...")
+        """
+
+        temp = tempfile.NamedTemporaryFile()
+        temp.write(str.encode(contract))
+        temp.flush()
+        compiler = Compiler.load(temp.name, use_nep8)
         return compiler

--- a/boa/compiler.py
+++ b/boa/compiler.py
@@ -87,7 +87,6 @@ class Compiler(object):
         avm = self.entry_module.write()
         return avm.hex()
 
-
     @staticmethod
     def load_and_save(path, output_path=None, use_nep8=True):
         """

--- a/boa_test/tests/test_compiler.py
+++ b/boa_test/tests/test_compiler.py
@@ -37,3 +37,27 @@ class TestContract(BoaTest):
         self.assertIsInstance(output, bytes)
 
         self.assertTrue(len(output) > 0)
+
+    def test_compile_3(self):
+
+        sc = """from boa.interop.Neo.App import RegisterAppCall
+from boa.interop.Neo.Runtime import Log
+from boa.interop.Neo.Iterator import Iterator
+
+enumerate = RegisterAppCall('1e68de2d4442b868c544b4104c8fe2172f580591', 'operation', 'args')
+
+def Main():
+    token_iter = enumerate('enumerate',[])
+    count = 0
+    result = []
+    while token_iter.next() and (count < 5):
+        result.append(token_iter.Value)
+        count += 1
+    return result"""
+
+        compiler = Compiler.load_contract(sc)
+
+        avm = compiler.write_contract()
+        expected = "59c56b09656e756d657261746500c176c97ce101029105582f17e28f4c10b444c568b842442dde681e6a00527ac4006a51527ac400c176c96a52527ac461616a00c368134e656f2e456e756d657261746f722e4e6578746434006a51c3559f642c006a52c36a00c368124e656f2e4974657261746f722e56616c756561c86a51c351936a51527ac462b6ff6161616a52c36c7566"
+
+        self.assertTrue(avm == expected)


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
Currently the only way to compile a python smart contract is to pass a path to the file to the compiler. There is no way compile a contract that is stored in a variable.

**What problem does this PR solve?**
Now contracts can be dynamically written and compiled without the need for a file for the contract.

**How did you solve this problem?**
I stored the contract into a temporary file, then compiled the temporary file.

**How did you make sure your solution works?**
I added a unit test to test this case.

**Are there any special changes in the code that we should be aware of?**
This adds an import of `tempfile`, which is built-in.

**Is there anything else we should know?**
N/A
