### PR TITLE
Add Neo Blockchain Toolkit Debugger support 

### DIFF
--- a/boa/code/method.py
+++ b/boa/code/method.py
@@ -3,7 +3,7 @@ from boa.code.vmtoken import VMTokenizer, Nep8VMTokenizer
 from boa.code.expression import Expression
 from boa.code import pyop
 from boa.code.ast_preprocess import preprocess_method_body
-from uuid import uuid4
+from uuid import UUID, uuid3
 
 import pdb
 import dis
@@ -98,8 +98,8 @@ class method(object):
         self.block = block
         self.module_name = module_name
         self._extra = extra
-        self._id = uuid4()
         self.name = self.block[1].arg
+        self._id = uuid3(UUID('{baa187e0-2c51-4ef6-aa42-b3421c22d5e1}'), self.full_name)
         self.start_line_no = self.block[0].lineno
         self.code_object = self.block[0].arg
 

--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -371,10 +371,41 @@ class Module(object):
         avm_name = os.path.splitext(os.path.basename(output_path))[0]
 
         json_data = self.generate_debug_json(avm_name, file_hash)
-
         mapfilename = output_path.replace('.avm', '.debug.json')
         with open(mapfilename, 'w+') as out_file:
             out_file.write(json_data)
+
+        json_data = self.generate_avmdbgnfo(avm_name, file_hash)
+        mapfilename = output_path.replace('.avm', '.avmdbgnfo.json')
+        with open(mapfilename, 'w+') as out_file:
+            out_file.write(json_data)
+
+    def generate_avmdbgnfo(self, avm_name, file_hash):
+
+        if self.all_vm_tokens is None:
+            self.link_methods()
+
+        data = {}
+        files = []
+        methods = []
+        events = []
+
+        for m in self.methods:
+            if m.is_interop:
+                continue
+            method = {}
+            method['id'] = m.id.urn
+            method['name'] = "{0},{1}".format(m.module.module_name,m.name)
+
+            methods.append(method)
+
+
+        data['entrypoint'] = self.main.id.urn
+        data['documents'] = files
+        data['methods'] = methods
+        data['events'] = events
+        json_data = json.dumps(data, indent=4)
+        return json_data
 
     def generate_debug_json(self, avm_name, file_hash):
 

--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -399,7 +399,7 @@ class Module(object):
             (_, start) = next(x for x in m.vm_tokens.items())
             (_, end) = next(x for x in reversed(m.vm_tokens.items()))
             method['range'] = '{}-{}'.format(start.addr, end.addr)
-            method['params'] = m.args
+            method['params'] = ["{},".format(a) for a in m.args]
             method['return'] = ""
             method['variables'] =[]
 
@@ -417,7 +417,7 @@ class Module(object):
                     lineno = pt.method_lineno + pt.lineno
 
                     if last_lineno != lineno:                    
-                        tokens.append("{}[{}]{}".format(value.addr, fileIndex, lineno))
+                        tokens.append("{}[{}]{}:0-{}:0".format(value.addr, fileIndex, lineno, lineno))
                         last_lineno = lineno
 
             methods.append(method)

--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -371,18 +371,12 @@ class Module(object):
 
         avm_name = os.path.splitext(os.path.basename(output_path))[0]
 
-        # json_data = self.generate_debug_json(avm_name, file_hash)
-        # mapfilename = output_path.replace('.avm', '.debug.json')
-        # with open(mapfilename, 'w+') as out_file:
-        #     out_file.write(json_data)
-
         debug_info = self.generate_avmdbgnfo(avm_name, file_hash)
         debug_json_filename = os.path.basename(output_path.replace('.avm', '.debug.json'))
         avmdbgnfo_filename = output_path.replace('.avm', '.avmdbgnfo')
 
         with zipfile.ZipFile(avmdbgnfo_filename, 'w', zipfile.ZIP_DEFLATED) as avmdbgnfo:
             avmdbgnfo.writestr(debug_json_filename, debug_info)
-
 
     def generate_avmdbgnfo(self, avm_name, file_hash):
 

--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -393,6 +393,7 @@ class Module(object):
         for m in self.methods:
             if m.is_interop:
                 continue
+
             method = {}
             method['id'] = m.id.urn
             method['name'] = "{0},{1}".format(m.module.module_name, m.name)
@@ -401,7 +402,8 @@ class Module(object):
             method['range'] = '{}-{}'.format(start.addr, end.addr)
             method['params'] = ["{},".format(a) for a in m.args]
             method['return'] = ""
-            method['variables'] =[]
+            argCount = len(m.args)
+            method['variables'] = ["{},".format(a[0]) for a in m.scope.items() if a[1] >= argCount]
 
             tokens = []
             last_lineno = None

--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -12,6 +12,7 @@ from collections import OrderedDict
 import os
 import sys
 import hashlib
+import zipfile 
 from boa import __version__
 import json
 
@@ -375,10 +376,13 @@ class Module(object):
         # with open(mapfilename, 'w+') as out_file:
         #     out_file.write(json_data)
 
-        json_data = self.generate_avmdbgnfo(avm_name, file_hash)
-        mapfilename = output_path.replace('.avm', '.debug.json')
-        with open(mapfilename, 'w+') as out_file:
-            out_file.write(json_data)
+        debug_info = self.generate_avmdbgnfo(avm_name, file_hash)
+        debug_json_filename = os.path.basename(output_path.replace('.avm', '.debug.json'))
+        avmdbgnfo_filename = output_path.replace('.avm', '.avmdbgnfo')
+
+        with zipfile.ZipFile(avmdbgnfo_filename, 'w', zipfile.ZIP_DEFLATED) as avmdbgnfo:
+            avmdbgnfo.writestr(debug_json_filename, debug_info)
+
 
     def generate_avmdbgnfo(self, avm_name, file_hash):
 


### PR DESCRIPTION
This PR modifies neo-boa to emit the avmdbgnfo format used by the [neo-debugger project](https://github.com/neo-project/neo-debugger). The format itself is documented in [Design Node NDX-DN11](https://github.com/ngdseattle/design-notes/blob/master/NDX-DN11%20-%20NEO%20Debug%20Info%20Specification.md#v10-format).

Note, as part of this change, I changed the UUID generated for boa.code.method.method._id to use a [name-based UUID](https://tools.ietf.org/html/rfc4122#section-4.3). This way, the UUID is stable between compilations.