### PR TITLE
Fix generating incorrect hash for ABI file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 venv/
 __pycache__
 .avm
+*.avmdbgnfo
+*.abi.json
 dist
 build
 neo_boa.egg-info

--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -5,7 +5,7 @@ from boa.code.appcall import appcall as BoaAppcall
 
 from boa.util import BlockType, get_block_type
 from bytecode import UNSET, Bytecode, BasicBlock, ControlFlowGraph, dump_bytecode, Label
-from boa.interop import VMOp
+from boa.interop import VMOp, Neo
 import importlib
 from logzero import logger
 from collections import OrderedDict
@@ -468,9 +468,9 @@ class Module(object):
         """
         this method is used to generate a debug map for NEO debugger
         """
-        file = open(output_path, 'rb')
-        file_hash = hashlib.md5(file.read()).hexdigest()
-        file.close()
+        with open(output_path, 'rb') as file:
+            script = Neo.to_script_hash(file.read())
+            file_hash = Neo.to_hex_str(script)
 
         avm_name = os.path.splitext(os.path.basename(output_path))[0]
 
@@ -479,7 +479,6 @@ class Module(object):
 
         with open(abi_json_filename, 'w+') as out_file:
             out_file.write(abi_info)
-            out_file.close()
 
     def generate_abi_json(self, avm_name, file_hash):
         # Initialize if needed

--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -499,6 +499,8 @@ class Module(object):
             data['entrypoint'] = 'Main'
         elif len(self.abi_methods) > 0:
             data['entrypoint'] = self.abi_methods.get(0)
+        else:
+            data['entrypoint'] = self.main.name
 
         data['functions'] = functions
         data['events'] = events

--- a/boa/interop/Neo/__init__.py
+++ b/boa/interop/Neo/__init__.py
@@ -1,0 +1,31 @@
+import hashlib
+
+
+def to_script_hash(byte_array) -> bytes:
+    """
+    Converts a data to a script hash.
+
+    :param byte_array: data to hash.
+    :type byte_array: bytearray or bytes
+
+    :return: the script hash of the data
+    :rtype: bytes
+    """
+    intermed = hashlib.sha256(byte_array).digest()
+    return hashlib.new('ripemd160', intermed).digest()
+
+
+def to_hex_str(data_bytes: bytes) -> str:
+    """
+    Converts bytes into its string hex representation.
+
+    :param data_bytes: data to represent as hex.
+    :type data_bytes: bytearray or bytes
+
+    :return: the hex representation of the data
+    :rtype: str
+    """
+    if isinstance(data_bytes, bytes):
+        data_bytes = bytearray(data_bytes)
+    data_bytes.reverse()
+    return '0x' + data_bytes.hex()

--- a/boa_test/example/AbiMethods8.py
+++ b/boa_test/example/AbiMethods8.py
@@ -1,0 +1,11 @@
+def method(operation, args):
+    if operation == 'add':
+        a = args[0]
+        b = args[1]
+        return add(a, b)
+    else:
+        return False
+
+
+def add(a, b):
+    return a + b

--- a/boa_test/tests/test_abi_methods.py
+++ b/boa_test/tests/test_abi_methods.py
@@ -120,3 +120,13 @@ class TestContract(BoaTest):
         self.assertEqual(main_params[0]['type'], 'String')
         self.assertEqual(main_params[1]['name'], 'args')
         self.assertEqual(main_params[1]['type'], 'Array')
+
+    def test_abi_method_without_decorator(self):
+        path = '%s/boa_test/example/AbiMethods8.py' % TestContract.dirname
+        output = Compiler.load(path).default
+        json_file = json.loads(output.generate_abi_json('AbiMethods8.avm', 'test'))
+
+        entry_point = json_file['entrypoint']
+        self.assertEqual(entry_point, 'method')
+        functions = json_file['functions']
+        self.assertEqual(len(functions), 0)

--- a/boa_test/tests/test_abi_methods.py
+++ b/boa_test/tests/test_abi_methods.py
@@ -1,4 +1,6 @@
 import json
+import os
+
 from boa.compiler import Compiler
 from boa_test.tests.boa_test import BoaTest
 
@@ -33,6 +35,34 @@ class TestContract(BoaTest):
         self.assertEqual(add_params[0]['type'], 'Integer')
         self.assertEqual(add_params[1]['name'], 'b')
         self.assertEqual(add_params[1]['type'], 'Integer')
+
+    def test_abi_script_hash_fail(self):
+        path = '%s/boa_test/example/AbiMethods1.py' % TestContract.dirname
+        abi_path = path.replace('.py', '.abi.json')
+        output = Compiler.load(path).default
+        output.export_abi_json(path.replace('.py', '.avm'))
+
+        self.assertTrue(os.path.exists(abi_path))
+        with open(abi_path, 'r') as abi_file:
+            json_file = json.loads(abi_file.read())
+
+        self.assertIn('hash', json_file)
+        script_hash = json_file['hash']
+        self.assertNotEqual(script_hash, 'a623cc41d62bf5783acde35fd105cdc4')
+
+    def test_abi_script_hash_success(self):
+        path = '%s/boa_test/example/AbiMethods1.py' % TestContract.dirname
+        abi_path = path.replace('.py', '.abi.json')
+        output = Compiler.load(path).default
+        output.export_abi_json(path.replace('.py', '.avm'))
+
+        self.assertTrue(os.path.exists(abi_path))
+        with open(abi_path, 'r') as abi_file:
+            json_file = json.loads(abi_file.read())
+
+        self.assertIn('hash', json_file)
+        script_hash = json_file['hash']
+        self.assertEqual(script_hash, '0xd0fce96885b76b14beed1c401af22d438ace50d4')
 
     def test_abi_methods_only_entry_point(self):
         path = '%s/boa_test/example/AbiMethods2.py' % TestContract.dirname

--- a/boa_test/tests/test_abi_methods.py
+++ b/boa_test/tests/test_abi_methods.py
@@ -39,8 +39,7 @@ class TestContract(BoaTest):
     def test_abi_script_hash_fail(self):
         path = '%s/boa_test/example/AbiMethods1.py' % TestContract.dirname
         abi_path = path.replace('.py', '.abi.json')
-        output = Compiler.load(path).default
-        output.export_abi_json(path.replace('.py', '.avm'))
+        Compiler.load_and_save(path)
 
         self.assertTrue(os.path.exists(abi_path))
         with open(abi_path, 'r') as abi_file:
@@ -53,8 +52,7 @@ class TestContract(BoaTest):
     def test_abi_script_hash_success(self):
         path = '%s/boa_test/example/AbiMethods1.py' % TestContract.dirname
         abi_path = path.replace('.py', '.abi.json')
-        output = Compiler.load(path).default
-        output.export_abi_json(path.replace('.py', '.avm'))
+        Compiler.load_and_save(path)
 
         self.assertTrue(os.path.exists(abi_path))
         with open(abi_path, 'r') as abi_file:


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
Fix #132 

**What problem does this PR solve?**
Fixes the incorrect hash in abi generation

**How did you solve this problem?**
Changed the algorithm used to hash the file.

**How did you make sure your solution works?**
Compared with the hash output from neo-cli when deploying the contracts and included unit tests.

**Are there any special changes in the code that we should be aware of?**
The `hexdigest()` function from `hashlib` was generating a reversed hash string. That's why we need to reverse the bytes before getting the string representation