### PR TITLE
Fix abi returntype casing

### DIFF
--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -515,7 +515,7 @@ class Module(object):
             function = {
                 'name': method,
                 'parameters': params,
-                'returnType': types['return']
+                'returntype': types['return']
             }
 
             functions.append(function)

--- a/boa_test/tests/test_abi_methods.py
+++ b/boa_test/tests/test_abi_methods.py
@@ -19,7 +19,7 @@ class TestContract(BoaTest):
         main_function = functions[0]
         main_params = main_function['parameters']
         self.assertEqual(main_function['name'], 'main')
-        self.assertEqual(main_function['returnType'], 'Any')
+        self.assertEqual(main_function['returntype'], 'Any')
         self.assertEqual(len(main_params), 2)
         self.assertEqual(main_params[0]['name'], 'operation')
         self.assertEqual(main_params[0]['type'], 'String')
@@ -29,7 +29,7 @@ class TestContract(BoaTest):
         add_function = functions[1]
         add_params = add_function['parameters']
         self.assertEqual(add_function['name'], 'add')
-        self.assertEqual(add_function['returnType'], 'Integer')
+        self.assertEqual(add_function['returntype'], 'Integer')
         self.assertEqual(len(add_params), 2)
         self.assertEqual(add_params[0]['name'], 'a')
         self.assertEqual(add_params[0]['type'], 'Integer')
@@ -75,7 +75,7 @@ class TestContract(BoaTest):
         main_function = functions[0]
         main_params = main_function['parameters']
         self.assertEqual(main_function['name'], 'main')
-        self.assertEqual(main_function['returnType'], 'Any')
+        self.assertEqual(main_function['returntype'], 'Any')
         self.assertEqual(len(main_params), 2)
         self.assertEqual(main_params[0]['name'], 'operation')
         self.assertEqual(main_params[0]['type'], 'String')
@@ -114,7 +114,7 @@ class TestContract(BoaTest):
         main_function = functions[0]
         main_params = main_function['parameters']
         self.assertEqual(main_function['name'], 'main')
-        self.assertEqual(main_function['returnType'], 'Void')
+        self.assertEqual(main_function['returntype'], 'Void')
         self.assertEqual(len(main_params), 2)
         self.assertEqual(main_params[0]['name'], 'operation')
         self.assertEqual(main_params[0]['type'], 'String')


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
Fix #135

**What problem does this PR solve?**
Fixes incorrect casing in .abi.json output so that it matches the Neon compiler output, improving compatibility with the Neo Blockchain Toolkit's Visual DevTracker.

**How did you solve this problem?**
Changed a big T to a little t.

**How did you make sure your solution works?**
Tested neo-boa contract detection in Visual DevTracker deploy menu before and after the change.

**Are there any special changes in the code that we should be aware of?**
Nope.